### PR TITLE
Precinct specific EDFs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,75 @@
+[[package]]
+name = "electos.nist-datamodels"
+version = "0.0.4"
+description = "Dataclasses for NIST SP-1500 schemas"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+pydantic = "1.8.2"
+
+[package.source]
+type = "file"
+url = ".local/tmp/electos.nist_datamodels-0.0.4-py3-none-any.whl"
+
+[[package]]
+name = "pydantic"
+version = "1.8.2"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.2.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "77bbac3f05c3bb37468e8d392048334fb18dd979952503b9450d74e162fa92d7"
+
+[metadata.files]
+"electos.nist-datamodels" = [
+    {file = "electos.nist_datamodels-0.0.4-py3-none-any.whl", hash = "sha256:f3cbd9bf9d12b5db2ecfa0f6cc1e77809b462e3d56e5fd9b657e130891578a6a"},
+]
+pydantic = [
+    {file = "pydantic-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:10e5622224245941efc193ad1d159887872776df7a8fd592ed746aa25d071840"},
+    {file = "pydantic-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:99a9fc39470010c45c161a1dc584997f1feb13f689ecf645f59bb4ba623e586b"},
+    {file = "pydantic-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a83db7205f60c6a86f2c44a61791d993dff4b73135df1973ecd9eed5ea0bda20"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:41b542c0b3c42dc17da70554bc6f38cbc30d7066d2c2815a94499b5684582ecb"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:ea5cb40a3b23b3265f6325727ddfc45141b08ed665458be8c6285e7b85bd73a1"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:18b5ea242dd3e62dbf89b2b0ec9ba6c7b5abaf6af85b95a97b00279f65845a23"},
+    {file = "pydantic-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:234a6c19f1c14e25e362cb05c68afb7f183eb931dd3cd4605eafff055ebbf287"},
+    {file = "pydantic-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e710876437bc07bd414ff453ac8ec63d219e7690128d925c6e82889d674bb505"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:ac8eed4ca3bd3aadc58a13c2aa93cd8a884bcf21cb019f8cfecaae3b6ce3746e"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4a03cbbe743e9c7247ceae6f0d8898f7a64bb65800a45cbdc52d65e370570820"},
+    {file = "pydantic-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:8621559dcf5afacf0069ed194278f35c255dc1a1385c28b32dd6c110fd6531b3"},
+    {file = "pydantic-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8b223557f9510cf0bfd8b01316bf6dd281cf41826607eada99662f5e4963f316"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:244ad78eeb388a43b0c927e74d3af78008e944074b7d0f4f696ddd5b2af43c62"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:05ef5246a7ffd2ce12a619cbb29f3307b7c4509307b1b49f456657b43529dc6f"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:54cd5121383f4a461ff7644c7ca20c0419d58052db70d8791eacbbe31528916b"},
+    {file = "pydantic-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3"},
+    {file = "pydantic-1.8.2-py3-none-any.whl", hash = "sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833"},
+    {file = "pydantic-1.8.2.tar.gz", hash = "sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-"electos.nist-datamodels" = {path = ".local/tmp/electos.nist_datamodels-0.0.4-py3-none-any.whl"}
+
+"electos.nist-datamodels" = { git = "https://github.com/ion-oset/nist-data-models.git", rev = "python/main" }
+
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Your Name <you@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-"electos.nist-datamodels" = { git = "https://github.com/ion-oset/nist-data-models.git", rev = "python/main" }
+"electos.nist-datamodels" = { git = "https://github.com/ion-oset/nist-data-models.git", rev = "python/v0.0.4" }
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "nist-1500-examples"
+version = "0.0.1"
+description = "NIST 1500 examples"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+"electos.nist-datamodels" = {path = ".local/tmp/electos.nist_datamodels-0.0.4-py3-none-any.whl"}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -1,0 +1,45 @@
+"""Extract single-precinct EDFs from multi-precinct EDFs."""
+
+# --- Display results
+
+def _show_item(item, output = None):
+    output = output or sys.stdout
+    print(json.dumps(item, indent = 4), file = output)
+
+
+# --- Main
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+# Contexts to show debugging output in
+_SHOW = ( "document", )
+
+
+def run(input_file, show, **opts):
+    assert input_file.is_file(), f"Not a file: {input_file}"
+    document = json.loads(input_file.read_text())
+    if "document" in show:
+        _show_item(document)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description = "Extract a valid single precinct EDF from a multi-precinct EDF.",
+    )
+    add = parser.add_argument
+    add("input_file", type = Path,
+        help = "EDF file to select precinct from")
+    add("--show", choices = _SHOW, action = "append", default = [],
+        help = "Contexts to show debugging output. Any of: " + ", ".join(_SHOW))
+    opts = parser.parse_args()
+    opts = vars(opts)
+    run(**opts)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -2,6 +2,7 @@
 
 from index import Index
 from selection import PrecinctSelection
+from extractor import PrecinctExtractor
 
 
 # --- Display results
@@ -59,6 +60,15 @@ def _show_precinct_selection(document, precinct_id, election_id):
         print()
 
 
+def _show_extracted_precinct(document, precinct_id, election_id):
+    print()
+    print("Extract Precinct")
+    print("----------------")
+    extractor = PrecinctExtractor()
+    precinct_document = extractor.extract_precinct(document, precinct_id, election_id)
+    _show_item(precinct_document)
+
+
 # --- Main
 
 import argparse
@@ -70,7 +80,7 @@ from pathlib import Path
 
 # Contexts to show debugging output in.
 # Would be replaced with 'logging' in a non-example application.
-_SHOW = ( "document", "index", "selection" )
+_SHOW = ( "document", "index", "selection", "extractor" )
 
 
 def run(input_file, precinct_id, election_id, show, **opts):
@@ -82,6 +92,8 @@ def run(input_file, precinct_id, election_id, show, **opts):
         _show_index(document)
     if "selection" in show:
         _show_precinct_selection(document, precinct_id, election_id)
+    if "extractor" in show:
+        _show_extracted_precinct(document, precinct_id, election_id)
 
 
 # Notes:

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -1,15 +1,19 @@
 """Extract single-precinct EDFs from multi-precinct EDFs."""
 
+from electos.datamodels.nist.models.base import NistModel
+from electos.datamodels.nist.models.edf import ElectionReport
+
 from index import Index
 from selection import PrecinctSelection
 from extractor import PrecinctExtractor
+from utility import json_save
 
 
 # --- Display results
 
 def _show_item(item, output = None):
     output = output or sys.stdout
-    print(json.dumps(item, indent = 4), file = output)
+    print(json.dumps(item, indent = 4, default = json_save), file = output)
 
 
 def _show_index(document):
@@ -85,7 +89,8 @@ _SHOW = ( "document", "index", "selection", "extractor" )
 
 def run(input_file, output_file, precinct_id, election_id, show, **opts):
     assert input_file.is_file(), f"Not a file: {input_file}"
-    document = json.loads(input_file.read_text())
+    data = json.loads(input_file.read_text())
+    document = ElectionReport(**data)
     if "document" in show:
         _show_item(document)
     if "index" in show:

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -39,6 +39,13 @@ def _show_precinct_selection(document, precinct_id, election_id):
     print("Precinct IDs")
     print("------------\n")
     selection = PrecinctSelection(document, precinct_id, election_id)
+    # Entry fields:
+    # - labels: Property key (as defined in the JSON Schema)
+    # - some: The properties present in the selection
+    #   These are always lists, even if empty
+    # - all: The properties present in the document
+    #   These are *not* always lists. They may be None if the property is not
+    #   defined in the document.
     entries = [
         ( "GP Units", selection.gp_units, selection._document.gp_unit ),
         ( "Headers",  selection.headers,  selection._document.header ),
@@ -52,6 +59,7 @@ def _show_precinct_selection(document, precinct_id, election_id):
         print(f"{label1}:")
         sep = "  - "
         nsep = f"\n{sep}"
+        # If the document property is None use an empty list so 'other' is defined.
         all = all or []
         other = [_ for _ in all if _ not in some]
         for label2, items in zip(("Precinct IDs", "Other IDs"), (some, other)):

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -40,13 +40,13 @@ def _show_precinct_selection(document, precinct_id, election_id):
     print("------------\n")
     selection = PrecinctSelection(document, precinct_id, election_id)
     entries = [
-        ( "GP Units", selection.gp_units, selection._document["GpUnit"] ),
-        ( "Headers",  selection.headers,  selection._document["Header"] ),
-        ( "Contests", selection.contests, selection._election["Contest"] ),
-        ( "Candidates", selection.candidates, selection._election["Candidate"] ),
-        ( "Offices", selection.offices,   selection._document["Office"] ),
-        ( "Parties", selection.parties,   selection._document["Party"] ),
-        ( "Persons", selection.persons,   selection._document["Person"] ),
+        ( "GP Units", selection.gp_units, selection._document.gp_unit ),
+        ( "Headers",  selection.headers,  selection._document.header ),
+        ( "Contests", selection.contests, selection._election.contest ),
+        ( "Candidates", selection.candidates, selection._election.candidate ),
+        ( "Offices", selection.offices,   selection._document.office ),
+        ( "Parties", selection.parties,   selection._document.party ),
+        ( "Persons", selection.persons,   selection._document.person ),
     ]
     for (label1, some, all) in entries:
         print(f"{label1}:")
@@ -58,7 +58,7 @@ def _show_precinct_selection(document, precinct_id, election_id):
                 print(f"  {label2}: none")
                 continue
             print(f"  {label2}:")
-            ids = [_["@id"] for _ in items if _]
+            ids = [_.model__id for _ in items if _]
             print(sep, end = "")
             print(nsep.join(ids))
         print()

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -52,6 +52,7 @@ def _show_precinct_selection(document, precinct_id, election_id):
         print(f"{label1}:")
         sep = "  - "
         nsep = f"\n{sep}"
+        all = all or []
         other = [_ for _ in all if _ not in some]
         for label2, items in zip(("Precinct IDs", "Other IDs"), (some, other)):
             if len(items) == 0:

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -20,13 +20,13 @@ def _show_index(document):
     print("IDs (types):")
     # Strip namespace prefix off of printed type
     n = len(index._namespace) + 1
-    for name, value in index._by_id.items():
-        print(f"- {name}: {value['@type'][n:]}")
+    for name, node in index._by_id.items():
+        print(f"- {name}: {node.value['@type'][n:]}")
     print()
     # Counts of elements by their type
     print("Types (counts):")
-    for name, values in index._by_type.items():
-        print(f"- {name}: {len(values)}")
+    for name, nodes in index._by_type.items():
+        print(f"- {name}: {len(nodes)}")
 
 
 def _show_precinct_selection(document, precinct_id, election_id):

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -1,10 +1,31 @@
 """Extract single-precinct EDFs from multi-precinct EDFs."""
 
+from index import Index
+
+
 # --- Display results
 
 def _show_item(item, output = None):
     output = output or sys.stdout
     print(json.dumps(item, indent = 4), file = output)
+
+
+def _show_index(document):
+    index = Index(document, "ElectionResults")
+    print()
+    print("Index")
+    print("-----\n")
+    # Types of elements by their ID
+    print("IDs (types):")
+    # Strip namespace prefix off of printed type
+    n = len(index._namespace) + 1
+    for name, value in index._by_id.items():
+        print(f"- {name}: {value['@type'][n:]}")
+    print()
+    # Counts of elements by their type
+    print("Types (counts):")
+    for name, values in index._by_type.items():
+        print(f"- {name}: {len(values)}")
 
 
 # --- Main
@@ -16,8 +37,9 @@ import sys
 from pathlib import Path
 
 
-# Contexts to show debugging output in
-_SHOW = ( "document", )
+# Contexts to show debugging output in.
+# Would be replaced with 'logging' in a non-example application.
+_SHOW = ( "document", "index" )
 
 
 def run(input_file, show, **opts):
@@ -25,6 +47,8 @@ def run(input_file, show, **opts):
     document = json.loads(input_file.read_text())
     if "document" in show:
         _show_item(document)
+    if "index" in show:
+        _show_index(document)
 
 
 def main():

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -134,14 +134,18 @@ def main():
     add("input_file", type = Path,
         help = "EDF file to select precinct from")
     add("precinct_id", type = int,
-        help = "ID (numeric index) of the BallotStyle of the precinct to extract")
-    add("election_id", type = int, nargs = "?", default = 0,
-        help = "ID (numeric index) of the Election to extract. (default: 0)")
+        help = "ID (>= 1) of the BallotStyle of the precinct to extract")
+    add("election_id", type = int, nargs = "?", default = 1,
+        help = "ID (>= 1)of the Election to extract. (default: 1)")
     add("-o", "--output-file", type = None,
         help = "EDF file with selected precinct (default: standard output)")
     add("--show", choices = _SHOW, action = "append", default = [],
         help = "Contexts to show debugging output. Any of: " + ", ".join(_SHOW))
     opts = parser.parse_args()
+    if opts.precinct_id <= 0:
+        raise ValueError(f"Precinct ID must be >= 1: {opts.precinct_id}")
+    if opts.election_id <= 0:
+        raise ValueError(f"Election ID must be >= 1: {opts.election_id}")
     opts = vars(opts)
     run(**opts)
 

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -26,7 +26,7 @@ def _show_index(document):
     # Strip namespace prefix off of printed type
     n = len(index._namespace) + 1
     for name, node in index._by_id.items():
-        print(f"- {name}: {node.value['@type'][n:]}")
+        print(f"- {name}: {node.value.model__type[n:]}")
     print()
     # Counts of elements by their type
     print("Types (counts):")

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -1,6 +1,7 @@
 """Extract single-precinct EDFs from multi-precinct EDFs."""
 
 from index import Index
+from selection import PrecinctSelection
 
 
 # --- Display results
@@ -28,6 +29,36 @@ def _show_index(document):
         print(f"- {name}: {len(values)}")
 
 
+def _show_precinct_selection(document, precinct_id, election_id):
+    print()
+    print("Precinct IDs")
+    print("------------\n")
+    selection = PrecinctSelection(document, precinct_id, election_id)
+    entries = [
+        ( "GP Units", selection.gp_units, selection._document["GpUnit"] ),
+        ( "Headers",  selection.headers,  selection._document["Header"] ),
+        ( "Contests", selection.contests, selection._election["Contest"] ),
+        ( "Candidates", selection.candidates, selection._election["Candidate"] ),
+        ( "Offices", selection.offices,   selection._document["Office"] ),
+        ( "Parties", selection.parties,   selection._document["Party"] ),
+        ( "Persons", selection.persons,   selection._document["Person"] ),
+    ]
+    for (label1, some, all) in entries:
+        print(f"{label1}:")
+        sep = "  - "
+        nsep = f"\n{sep}"
+        other = [_ for _ in all if _ not in some]
+        for label2, items in zip(("Precinct IDs", "Other IDs"), (some, other)):
+            if len(items) == 0:
+                print(f"  {label2}: none")
+                continue
+            print(f"  {label2}:")
+            ids = [_["@id"] for _ in items if _]
+            print(sep, end = "")
+            print(nsep.join(ids))
+        print()
+
+
 # --- Main
 
 import argparse
@@ -39,17 +70,27 @@ from pathlib import Path
 
 # Contexts to show debugging output in.
 # Would be replaced with 'logging' in a non-example application.
-_SHOW = ( "document", "index" )
+_SHOW = ( "document", "index", "selection" )
 
 
-def run(input_file, show, **opts):
+def run(input_file, precinct_id, election_id, show, **opts):
     assert input_file.is_file(), f"Not a file: {input_file}"
     document = json.loads(input_file.read_text())
     if "document" in show:
         _show_item(document)
     if "index" in show:
         _show_index(document)
+    if "selection" in show:
+        _show_precinct_selection(document, precinct_id, election_id)
 
+
+# Notes:
+# - Precinct IDs are not names. They are numeric indexes starting at 0.
+#   The reason is that BallotStyles have no '@id'. This could be changed to also
+#   allow the 'ExternalIdentifier' to be used, but BallotStyles are not required
+#   to have one.
+# - Election IDs are optional because there is usually only one election.
+#   They are kept as numeric indexes for consistency with precinct IDs.
 
 def main():
     parser = argparse.ArgumentParser(
@@ -58,6 +99,10 @@ def main():
     add = parser.add_argument
     add("input_file", type = Path,
         help = "EDF file to select precinct from")
+    add("precinct_id", type = int,
+        help = "ID (numeric index) of the BallotStyle of the precinct to extract")
+    add("election_id", type = int, nargs = "?", default = 0,
+        help = "ID (numeric index) of the Election to extract. (default: 0)")
     add("--show", choices = _SHOW, action = "append", default = [],
         help = "Contexts to show debugging output. Any of: " + ", ".join(_SHOW))
     opts = parser.parse_args()

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -93,7 +93,7 @@ from pathlib import Path
 
 # Contexts to show debugging output in.
 # Would be replaced with 'logging' in a non-example application.
-_SHOW = ( "document", "index", "selection", "extractor" )
+_SHOW = ( "document", "index", "selection", "extraction" )
 
 
 def run(input_file, output_file, precinct_id, election_id, show, **opts):
@@ -106,7 +106,7 @@ def run(input_file, output_file, precinct_id, election_id, show, **opts):
         _show_index(document)
     if "selection" in show:
         _show_precinct_selection(document, precinct_id, election_id)
-    if "extractor" in show:
+    if "extraction" in show:
         _show_extracted_precinct(document, precinct_id, election_id)
     if output_file:
         output_file = Path(output_file)

--- a/scripts/extract-precincts.py
+++ b/scripts/extract-precincts.py
@@ -13,7 +13,7 @@ from utility import json_save
 
 def _show_item(item, output = None):
     output = output or sys.stdout
-    print(json.dumps(item, indent = 4, default = json_save), file = output)
+    print(item.json(indent = 4), file = output)
 
 
 def _show_index(document):

--- a/scripts/extractor.py
+++ b/scripts/extractor.py
@@ -27,7 +27,7 @@ class PrecinctExtractor:
         selection = PrecinctSelection(document, precinct_id, election_id)
         # Ballot styles have no '@id', so 'ids_of' won't work.
         # Since there's only one ballot style for the precinct this doesn't matter.
-        document["Election"][election_id]["BallotStyle"] = [selection.ballot_style]
+        document.election[election_id].ballot_style = [selection.ballot_style]
         for name, ids in (
             ( "Contest", ids_of(selection.contests) ),
             ( "Candidate", ids_of(selection.candidates) ),
@@ -47,7 +47,7 @@ class PrecinctExtractor:
         keys = []
         for node in index.by_type(type_name):
             item = node.value
-            if item["@id"] not in reachable_ids:
+            if item.model__id not in reachable_ids:
                 keys.append(node.key)
         # Delete from end to beginning so that indexes don't change if item
         # is a list. If node is a dict this is unnecessary but harmless.

--- a/scripts/extractor.py
+++ b/scripts/extractor.py
@@ -1,0 +1,56 @@
+"""Precinct extraction."""
+
+import copy
+
+from index import Index
+from selection import PrecinctSelection
+from utility import ids_of
+
+
+class PrecinctExtractor:
+
+    """Extract a single precinct EDF from a combined EDF."""
+
+
+    def extract_precinct(self, document, precinct_id, election_id = 0):
+        """Extractor for precinct EDF records.
+
+        Parameters:
+            document: EDF document
+            precinct_id: ID (numeric index) for root 'BallotStyle'.
+            election_id: ID (numeric index) for 'Election'.
+                default: 0. There is usually only one 'Election'.
+        """
+        # Make a copy so the original document isn't clobbered.
+        document = copy.deepcopy(document)
+        index = Index(document, "ElectionResults")
+        selection = PrecinctSelection(document, precinct_id, election_id)
+        # Ballot styles have no '@id', so 'ids_of' won't work.
+        # Since there's only one ballot style for the precinct this doesn't matter.
+        document["Election"][election_id]["BallotStyle"] = [selection.ballot_style]
+        for name, ids in (
+            ( "Contest", ids_of(selection.contests) ),
+            ( "Candidate", ids_of(selection.candidates) ),
+            ( "ReportingUnit", ids_of(selection.gp_units) ),
+            ( "Header", ids_of(selection.headers) ),
+            ( "Office", ids_of(selection.offices) ),
+            ( "Party", ids_of(selection.parties) ),
+            ( "Person", ids_of(selection.persons) ),
+        ):
+            self._remove_unreached_elements(index, name, ids)
+        return document
+
+
+    def _remove_unreached_elements(self, index, type_name, reachable_ids):
+        """Remove elements that aren't part of the precinct.
+        This means elements that aren't reachable from the root BallotStyle."""
+        keys = []
+        for node in index.by_type(type_name):
+            item = node.value
+            if item["@id"] not in reachable_ids:
+                keys.append(node.key)
+        # Delete from end to beginning so that indexes don't change if item
+        # is a list. If node is a dict this is unnecessary but harmless.
+        keys.reverse()
+        for key in keys:
+            del node.parent[key]

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -1,0 +1,63 @@
+"""Document index."""
+
+
+from collections.abc import Mapping
+
+from utility import walk_document
+
+
+class Index:
+
+    """Indexes of all elements by their '@id' and '@type'.
+
+    Provides a limited DOM-like interface.
+    """
+
+    def __init__(self, document, namespace):
+        # Document to index
+        self._document = document
+        # Namespace prefix
+        self._namespace = namespace
+        # Index of elements by '@id'
+        self._by_id = {}
+        # Index of elements by '@type'
+        self._by_type = {}
+        self._build_indexes()
+
+
+    def by_id(self, id, strict = False):
+        """Return element whose '@id' is 'id'.
+
+        Preserves document order.
+        """
+        id_ = id
+        item = self._by_id.get(id_, None)
+        if not item and strict:
+            raise KeyError(f"No item in index with '@id': {id_}")
+        return item
+
+
+    def by_type(self, type, strict = False, with_namespace = True):
+        """Yield all elements whose '@type' is 'type'.
+
+        Preserves document order.
+        """
+
+        type_ = type
+        if with_namespace and "." not in type_:
+            type_ = f"{self._namespace}.{type_}"
+        items = self._by_type.get(type_, [])
+        if not items and strict:
+            raise KeyError(f"No items in index with '@type': {type_}")
+        for item in items:
+            yield item
+
+
+    def _build_indexes(self):
+        """Build the ID and type indexes."""
+        for item in walk_document(self._document):
+            if isinstance(item, Mapping):
+                if "@id" in item:
+                    self._by_id[item["@id"]] = item
+                if "@type" in item:
+                    self._by_type.setdefault(item["@type"], []).append(item)

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -3,6 +3,8 @@
 
 from collections.abc import Mapping
 
+from electos.datamodels.nist.models.base import NistModel
+
 from utility import walk_document
 
 
@@ -115,9 +117,9 @@ class Index:
     def _build_indexes(self):
         """Build the ID and type indexes."""
         for item, key, value in walk_document(self._document):
-            if isinstance(value, Mapping):
+            if isinstance(value, NistModel):
                 node = IndexNode(item, key, value)
-                if "@id" in value:
-                    self._by_id[value["@id"]] = node
-                if "@type" in value:
-                    self._by_type.setdefault(value["@type"], []).append(node)
+                if hasattr(value, "model__id"):
+                    self._by_id[value.model__id] = node
+                if hasattr(value, "model__type"):
+                    self._by_type.setdefault(value.model__type, []).append(node)

--- a/scripts/selection.py
+++ b/scripts/selection.py
@@ -35,21 +35,24 @@ class PrecinctSelection:
     def candidates(self):
         """Candidates in the precinct. Derived fron the candidate contests."""
         candidates = self._election.candidate
-        ids = [
-            contest_selection.candidate_ids
-            # Only look at candidate contests
-            for contest in self.contests
-                if contest.model__type == "ElectionResults.CandidateContest"
-            # Limit to selections with candidate IDs.
-            # Write-ins are candidate contest selections but have no IDs.
-            for contest_selection in contest.contest_selection
-                if hasattr(contest_selection, "CandidateIds")
-        ]
-        ids = reduce(lambda x, y: x + y, ids, [])
-        results = [
-            candidate
-            for candidate in candidates if candidate.model__id in ids
-        ]
+        if not candidates:
+            results = []
+        else:
+            ids = [
+                contest_selection.candidate_ids
+                # Only look at candidate contests
+                for contest in self.contests
+                    if contest.model__type == "ElectionResults.CandidateContest"
+                # Limit to selections with candidate IDs.
+                # Write-ins are candidate contest selections but have no IDs.
+                for contest_selection in contest.contest_selection
+                    if hasattr(contest_selection, "CandidateIds")
+            ]
+            ids = reduce(lambda x, y: x + y, ids, [])
+            results = [
+                candidate
+                for candidate in candidates if candidate.model__id in ids
+            ]
         return results
 
 
@@ -57,15 +60,18 @@ class PrecinctSelection:
     def contests(self):
         """Contests in the precinct. Derived from the ballot style."""
         contests = self._election.contest
-        ids = [
-            item2.contest_id
-            for item1 in self.ballot_style.ordered_content
-            for item2 in item1.ordered_content
-        ]
-        results = [
-            contest
-            for contest in contests if contest.model__id in ids
-        ]
+        if not contests:
+            return results
+        else:
+            ids = [
+                item2.contest_id
+                for item1 in self.ballot_style.ordered_content
+                for item2 in item1.ordered_content
+            ]
+            results = [
+                contest
+                for contest in contests if contest.model__id in ids
+            ]
         return results
 
 
@@ -73,12 +79,15 @@ class PrecinctSelection:
     def gp_units(self):
         """Geo-political unit for the precinct. Extracted from election report."""
         gp_units = self._document.gp_unit
-        ids = self.ballot_style.gp_unit_ids
-        results = [
-            gp_unit
-            for gp_unit in gp_units if gp_unit.model__id in ids
-        ]
-        assert len(results) == 1, "More than one GpUnit for precinct"
+        if not gp_units:
+            results = []
+        else:
+            ids = self.ballot_style.gp_unit_ids
+            results = [
+                gp_unit
+                for gp_unit in gp_units if gp_unit.model__id in ids
+            ]
+            assert len(results) == 1, "More than one GpUnit for precinct"
         return results
 
 
@@ -86,14 +95,17 @@ class PrecinctSelection:
     def headers(self):
         """Ballot headers for the precinct. Extracted from the election report."""
         headers = self._document.header
-        ids = [
-            item.header_id
-            for item in self.ballot_style.ordered_content
-        ]
-        results = [
-            header
-            for header in headers if header.model__id in ids
-        ]
+        if not headers:
+            results = []
+        else:
+            ids = [
+                item.header_id
+                for item in self.ballot_style.ordered_content
+            ]
+            results = [
+                header
+                for header in headers if header.model__id in ids
+            ]
         return results
 
 
@@ -101,17 +113,20 @@ class PrecinctSelection:
     def offices(self):
         """Offices for the precinct. Derived from the candidate contests."""
         offices = self._document.office
-        ids = [
-            contest.office_ids
-            # Only candidate contests have offices
-            for contest in self.contests
-                if contest.model__type == "ElectionResults.CandidateContest"
-        ]
-        ids = reduce(lambda x, y: x + y, ids, [])
-        results = [
-            office
-            for office in offices if office.model__id in ids
-        ]
+        if not offices:
+            results = []
+        else:
+            ids = [
+                contest.office_ids
+                # Only candidate contests have offices
+                for contest in self.contests
+                    if contest.model__type == "ElectionResults.CandidateContest"
+            ]
+            ids = reduce(lambda x, y: x + y, ids, [])
+            results = [
+                office
+                for office in offices if office.model__id in ids
+            ]
         return results
 
 
@@ -119,16 +134,19 @@ class PrecinctSelection:
     def parties(self):
         """Parties for the precinct. Derived from the candidates."""
         parties = self._document.party
-        ids = [
-            candidate.party_id
-            # Not all candidates have a party
-            for candidate in self.candidates
-                if hasattr(candidate, "PartyId")
-        ]
-        results = [
-            party
-            for party in parties if party.model__id in ids
-        ]
+        if not parties:
+            results = []
+        else:
+            ids = [
+                candidate.party_id
+                # Not all candidates have a party
+                for candidate in self.candidates
+                    if hasattr(candidate, "PartyId")
+            ]
+            results = [
+                party
+                for party in parties if party.model__id in ids
+            ]
         return results
 
 
@@ -136,16 +154,19 @@ class PrecinctSelection:
     def persons(self):
         """Persons for the precinct. Derived from the candidates."""
         persons = self._document.person
-        ids = [
-            candidate.person_id
-            for candidate in self.candidates
-        ]
-        results = [
-            person
-            # Note: Technically a Candidate can have 0 Persons.
-            # It's not clear under what circumstances that can occur.
-            for person in persons if person.model__id in ids
-        ]
+        if not persons:
+            results = []
+        else:
+            ids = [
+                candidate.person_id
+                for candidate in self.candidates
+            ]
+            results = [
+                person
+                # Note: Technically a Candidate can have 0 Persons.
+                # It's not clear under what circumstances that can occur.
+                for person in persons if person.model__id in ids
+            ]
         return results
 
 

--- a/scripts/selection.py
+++ b/scripts/selection.py
@@ -1,0 +1,159 @@
+from functools import cached_property, reduce
+
+
+class PrecinctSelection:
+
+    """Selection of all elements in an EDF that belong to a single precinct."""
+
+    # Note: Order of properties is declaration order (i.e. being preserved).
+
+    def __init__(self, document, precinct_id, election_id = 0):
+        """Construct a precinct selection from an EDF.
+
+        Parameters:
+            document: EDF document
+            precinct_id: ID (numeric index) for root 'BallotStyle'.
+            election_id: ID (numeric index) for 'Election'.
+                default: 0. There is usually only one 'Election'.
+        """
+        self._document = document
+        self._precinct_id = precinct_id
+        self._election_id = election_id
+
+
+    @cached_property
+    def ballot_style(self):
+        """The selected ballot style. Extracted from election report.
+
+        This is the root of the extraction, so there is only one.
+        """
+        result = self._election["BallotStyle"][self._precinct_id]
+        return result
+
+
+    @cached_property
+    def candidates(self):
+        """Candidates in the precinct. Derived fron the candidate contests."""
+        candidates = self._election["Candidate"]
+        ids = [
+            contest_selection["CandidateIds"]
+            # Only look at candidate contests
+            for contest in self.contests
+                if contest["@type"] == "ElectionResults.CandidateContest"
+            # Limit to selections with candidate IDs.
+            # Write-ins are candidate contest selections but have no IDs.
+            for contest_selection in contest["ContestSelection"]
+                if "CandidateIds" in contest_selection
+        ]
+        ids = reduce(lambda x, y: x + y, ids, [])
+        results = [
+            candidate
+            for candidate in candidates if candidate["@id"] in ids
+        ]
+        return results
+
+
+    @cached_property
+    def contests(self):
+        """Contests in the precinct. Derived from the ballot style."""
+        contests = self._election["Contest"]
+        ids = [
+            item2["ContestId"]
+            for item1 in self.ballot_style["OrderedContent"]
+            for item2 in item1["OrderedContent"]
+        ]
+        results = [
+            contest
+            for contest in contests if contest["@id"] in ids
+        ]
+        return results
+
+
+    @cached_property
+    def gp_units(self):
+        """Geo-political unit for the precinct. Extracted from election report."""
+        gp_units = self._document["GpUnit"]
+        ids = self.ballot_style["GpUnitIds"]
+        results = [
+            gp_unit
+            for gp_unit in gp_units if gp_unit["@id"] in ids
+        ]
+        assert len(results) == 1, "More than one GpUnit for precinct"
+        return results
+
+
+    @cached_property
+    def headers(self):
+        """Ballot headers for the precinct. Extracted from the election report."""
+        headers = self._document["Header"]
+        ids = [
+            item["HeaderId"]
+            for item in self.ballot_style["OrderedContent"]
+        ]
+        results = [
+            header
+            for header in headers if header["@id"] in ids
+        ]
+        return results
+
+
+    @cached_property
+    def offices(self):
+        """Offices for the precinct. Derived from the candidate contests."""
+        offices = self._document["Office"]
+        ids = [
+            contest["OfficeIds"]
+            # Only candidate contests have offices
+            for contest in self.contests
+                if contest["@type"] == "ElectionResults.CandidateContest"
+        ]
+        ids = reduce(lambda x, y: x + y, ids, [])
+        results = [
+            office
+            for office in offices if office["@id"] in ids
+        ]
+        return results
+
+
+    @cached_property
+    def parties(self):
+        """Parties for the precinct. Derived from the candidates."""
+        parties = self._document["Party"]
+        ids = [
+            candidate["PartyId"]
+            # Not all candidates have a party
+            for candidate in self.candidates
+                if "PartyId" in candidate
+        ]
+        results = [
+            party
+            for party in parties if party["@id"] in ids
+        ]
+        return results
+
+
+    @cached_property
+    def persons(self):
+        """Persons for the precinct. Derived from the candidates."""
+        persons = self._document["Person"]
+        ids = [
+            candidate["PersonId"]
+            for candidate in self.candidates
+        ]
+        results = [
+            person
+            # Note: Technically a Candidate can have 0 Persons.
+            # It's not clear under what circumstances that can occur.
+            for person in persons if person["@id"] in ids
+        ]
+        return results
+
+
+    # --- Properties: Internal
+
+    @cached_property
+    def _election(self):
+        elections = self._document["Election"]
+        election = elections[self._election_id]
+        return election
+

--- a/scripts/selection.py
+++ b/scripts/selection.py
@@ -28,8 +28,8 @@ class PrecinctSelection:
                 default: 0. There is usually only one 'Election'.
         """
         self._document = document
-        self._precinct_id = precinct_id
-        self._election_id = election_id
+        self._precinct_id = precinct_id - 1
+        self._election_id = election_id - 1
 
 
     @cached_property
@@ -40,8 +40,13 @@ class PrecinctSelection:
         """
         # If the ballot style is missing an error will be raised here.
         # TODO: A selection is not possible without a ballot style so this
-        # check should come earlier.
-        result = self._election.ballot_style[self._precinct_id]
+        # check should come earlier.l
+        try:
+            result = self._election.ballot_style[self._precinct_id]
+        except IndexError as ex:
+            index = self._precinct_id + 1
+            length = len(self._election.ballot_style)
+            raise IndexError(f"Precinct ID is out of range ([1-{length}]): {index}")
         return result
 
 

--- a/scripts/selection.py
+++ b/scripts/selection.py
@@ -5,9 +5,18 @@ from electos.datamodels.nist.models.edf import OrderedContest, OrderedHeader
 
 class PrecinctSelection:
 
-    """Selection of all elements in an EDF that belong to a single precinct."""
+    """Selection of all elements in an EDF that belong to a single precinct.
 
-    # Note: Order of properties is declaration order (i.e. being preserved).
+    Notes:
+
+    - All properties are either from 'ElectionReport' or 'Election'.
+    - The order of properties is the declaration order from document.
+    - Most selections may be empty as nearly all the properties are optional.
+      This is a result of the JSON Schema being unconstrained: EDFs can be pass
+      schema validation and still not be possible.
+    - Modifying the selection should NOT modify the property on the original
+      document. (This is not currently being tested.)
+    """
 
     def __init__(self, document, precinct_id, election_id = 0):
         """Construct a precinct selection from an EDF.
@@ -29,6 +38,9 @@ class PrecinctSelection:
 
         This is the root of the extraction, so there is only one.
         """
+        # If the ballot style is missing an error will be raised here.
+        # TODO: A selection is not possible without a ballot style so this
+        # check should come earlier.
         result = self._election.ballot_style[self._precinct_id]
         return result
 

--- a/scripts/selection.py
+++ b/scripts/selection.py
@@ -44,9 +44,10 @@ class PrecinctSelection:
                 for contest in self.contests
                     if contest.model__type == "ElectionResults.CandidateContest"
                 # Limit to selections with candidate IDs.
-                # Write-ins are candidate contest selections but have no IDs.
+                # Write-ins are candidate contest selections and they *have* a
+                # 'CandidateId' property but it is null.
                 for contest_selection in contest.contest_selection
-                    if hasattr(contest_selection, "CandidateIds")
+                    if getattr(contest_selection, "candidate_ids", None) != None
             ]
             ids = reduce(lambda x, y: x + y, ids, [])
             results = [
@@ -141,7 +142,7 @@ class PrecinctSelection:
                 candidate.party_id
                 # Not all candidates have a party
                 for candidate in self.candidates
-                    if hasattr(candidate, "PartyId")
+                    if hasattr(candidate, "party_id")
             ]
             results = [
                 party

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,0 +1,23 @@
+"""Utilities."""
+
+from collections.abc import Sequence, Mapping
+
+
+def walk_document(item):
+    """Walk all objects in a document, depth first.
+
+    Note: JSON objects are Python dictionaries.
+
+    Parameters:
+        item: A mapping to walk the fields of.
+
+    Yields:
+        Every object in the walk.
+    """
+    yield item
+    if isinstance(item, Mapping):
+        for value in item.values():
+            yield from walk_document(value)
+    elif isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+        for value in item:
+            yield from walk_document(value)

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -3,6 +3,11 @@
 from collections.abc import Sequence, Mapping
 
 
+def ids_of(items):
+    """Get JSON Schema '@id's from a list of elements."""
+    return [item["@id"] for item in items]
+
+
 def walk_document(parent):
     """Walk all objects in a document, depth first.
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -49,8 +49,9 @@ def walk_document(parent):
         - For a mapping or sequence: 'parent[key]'
         - For a scalar: the 'parent'
     """
-    if isinstance(parent, Mapping):
-        for name, value in parent.items():
+    if isinstance(parent, NistModel):
+        for name in parent.__fields__.keys():
+            value = getattr(parent, name)
             yield parent, name, value
             yield from walk_document(value)
     elif isinstance(parent, Sequence) and not isinstance(parent, (str, bytes)):
@@ -58,5 +59,7 @@ def walk_document(parent):
             yield parent, index, value
             yield from walk_document(value)
     else:
+        assert not isinstance(parent, Mapping), \
+              f"There should be no mappings in a model: {parent}"
         parent, key, value = None, None, parent
         yield parent, key, value

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -1,11 +1,28 @@
 """Utilities."""
 
 from collections.abc import Sequence, Mapping
+from datetime import date as Date, datetime as DateTime
+from enum import Enum
+
+from electos.datamodels.nist.models.base import NistModel
 
 
 def ids_of(items):
     """Get JSON Schema '@id's from a list of elements."""
     return [item["@id"] for item in items]
+
+
+def json_save(item):
+    """JSON type conversions for types not covered by 'json.dump'."""
+    if isinstance(item, NistModel):
+        return item.dict()
+    elif isinstance(item, Enum):
+        return item.value
+    elif isinstance(item, Date):
+        return item.strftime("%Y-%m-%d")
+    elif isinstance(item, DateTime):
+        return item.strftime("%Y-%m-%d")
+    raise TypeError(f"Cannot convert '{type(item).__name__}' to JSON: {item}")
 
 
 def walk_document(parent):

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -3,21 +3,38 @@
 from collections.abc import Sequence, Mapping
 
 
-def walk_document(item):
+def walk_document(parent):
     """Walk all objects in a document, depth first.
 
-    Note: JSON objects are Python dictionaries.
+    Yields the objects and their parent objects, to allow basic mutations at
+    each step.
+    - Mappings yield key, value pairs.
+    - Sequences yield index, value pairs.
+    - Scalars yield themselves.
 
     Parameters:
-        item: A mapping to walk the fields of.
+        parent: The object being walked.
 
     Yields:
-        Every object in the walk.
+        parent: Parent item of the value
+        - For a mapping or sequence: the input 'parent'.
+        - For a scalar: None
+        key: The key used to access the value.
+        - For a mapping: key
+        - For a sequence: numeric index
+        - For a scalar: None
+        value: The value.
+        - For a mapping or sequence: 'parent[key]'
+        - For a scalar: the 'parent'
     """
-    yield item
-    if isinstance(item, Mapping):
-        for value in item.values():
+    if isinstance(parent, Mapping):
+        for name, value in parent.items():
+            yield parent, name, value
             yield from walk_document(value)
-    elif isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
-        for value in item:
+    elif isinstance(parent, Sequence) and not isinstance(parent, (str, bytes)):
+        for index, value in enumerate(parent):
+            yield parent, index, value
             yield from walk_document(value)
+    else:
+        parent, key, value = None, None, parent
+        yield parent, key, value

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -9,7 +9,7 @@ from electos.datamodels.nist.models.base import NistModel
 
 def ids_of(items):
     """Get JSON Schema '@id's from a list of elements."""
-    return [item["@id"] for item in items]
+    return [item.model__id for item in items]
 
 
 def json_save(item):

--- a/test_cases/april_precinct_1_test_case.json
+++ b/test_cases/april_precinct_1_test_case.json
@@ -1,0 +1,345 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_1_downtown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recFIehh5Aj0zGTn6"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recOVSnILnPJ7Dahl",
+            "EndDate": "2022-06-14",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Special Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2022-06-14",
+            "Type": "special"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-17T17:43:07+00:00",
+    "GpUnit": [
+        {
+            "@id": "recFIehh5Aj0zGTn6",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Downtown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Downtown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/april_precinct_2_test_case.json
+++ b/test_cases/april_precinct_2_test_case.json
@@ -1,0 +1,202 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_4_bedrock"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recSQ3ZpvJlTll1Ve"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [],
+            "Contest": [
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recOVSnILnPJ7Dahl",
+            "EndDate": "2022-06-14",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Special Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2022-06-14",
+            "Type": "special"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-17T17:43:07+00:00",
+    "GpUnit": [
+        {
+            "@id": "recSQ3ZpvJlTll1Ve",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Bedrock",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Bedrock Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [],
+    "Party": [],
+    "Person": [],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/april_precinct_3_test_case.json
+++ b/test_cases/april_precinct_3_test_case.json
@@ -1,0 +1,325 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_3_spaceport"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "rec7dCergEa3mzqxy"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recOVSnILnPJ7Dahl",
+            "EndDate": "2022-06-14",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Special Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2022-06-14",
+            "Type": "special"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-17T17:43:07+00:00",
+    "GpUnit": [
+        {
+            "@id": "rec7dCergEa3mzqxy",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Port",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Port Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [],
+    "Person": [
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/april_precinct_4_test_case.json
+++ b/test_cases/april_precinct_4_test_case.json
@@ -1,0 +1,465 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_2_spacetown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recUuJTc3tUIUvgF1"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                },
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recOVSnILnPJ7Dahl",
+            "EndDate": "2022-06-14",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Special Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2022-06-14",
+            "Type": "special"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-17T17:43:07+00:00",
+    "GpUnit": [
+        {
+            "@id": "recUuJTc3tUIUvgF1",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spacetown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spacetown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/april_test_case.json
+++ b/test_cases/april_test_case.json
@@ -1,0 +1,935 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_1_downtown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recFIehh5Aj0zGTn6"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_4_bedrock"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recSQ3ZpvJlTll1Ve"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_3_spaceport"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "rec7dCergEa3mzqxy"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_2_spacetown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recUuJTc3tUIUvgF1"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                },
+                {
+                    "@id": "recV5d7CnhUw5NoOl",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Mayor",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                },
+                {
+                    "@id": "rec4qAek7djJBFktw",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Control Board 1",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "recVwhaX6QKaOPSjc",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Control Board 2",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recOVSnILnPJ7Dahl",
+            "EndDate": "2022-06-14",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Special Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2022-06-14",
+            "Type": "special"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-17T17:43:07+00:00",
+    "GpUnit": [
+        {
+            "@id": "rec7dCergEa3mzqxy",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Port",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Port Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "rec93s713Yh6ZJT31",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Farallon",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The State of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "state"
+        },
+        {
+            "@id": "recFIehh5Aj0zGTn6",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Downtown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Downtown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recOVSnILnPJ7Dahl",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Gadget",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "county"
+        },
+        {
+            "@id": "recSQ3ZpvJlTll1Ve",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Bedrock",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Bedrock Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recTXCMIfa5VQJju2",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "USA",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "United States of America",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "country"
+        },
+        {
+            "@id": "recUuJTc3tUIUvgF1",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spacetown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spacetown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recVAsRw7BvEIBnTe",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Gadget School District",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County Unified School District",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "school"
+        },
+        {
+            "@id": "recVN5dRsq4j6QZn3",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Aldrin Space Transport District",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "municipality"
+        },
+        {
+            "@id": "recfK8xOapcRIeZ2k",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Orbit City",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "city"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec1zWmGWlgKKmUO4",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "School Board",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County School Board",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recIR57LPmJ0VvtEo",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "VPOTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Vice-President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec15uIXhHcriFgTS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "industrialist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recCHZSZuP5uTRqdk",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "baker",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recMZnE37A32cUq8t",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rosashawn",
+            "LastName": "Davis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "writer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recSUfKMVoKsAAMkS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "artist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recjdr7s1JWS9eB7J",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "professor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/edf_jetsons_precinct_1.json
+++ b/test_cases/edf_jetsons_precinct_1.json
@@ -1,0 +1,921 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Format": "precinct-level",
+    "GeneratedDate": "2062-01-01T12:00:00-08:00",
+    "VendorApplicationId": "TTV",
+    "Issuer": "Gadget County",
+    "IssuerAbbreviation": "gc",
+    "SequenceStart": 1,
+    "SequenceEnd": 1,
+    "Status": "pre-election",
+    "Header": [
+        {
+            "@id": "header_national",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "National Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_state",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "State Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_county",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "County Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_district",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "District Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        }
+    ],
+    "GpUnit": [
+        {
+            "Type": "precinct",
+            "@type": "ElectionResults.ReportingUnit",
+            "@id": "precinct_1_downtown",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Downtown Orbit City Precinct",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            }
+        }
+    ],
+    "Office": [
+        {
+            "@id": "office_mayor",
+            "ElectionDistrictId": "district_orbit_city",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "office_school_board",
+            "ElectionDistrictId": "district_unified_school_district",
+            "IsPartisan": false,
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Gadget County School Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "potus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "vpotus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Vice President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        }
+    ],
+    "Party": [
+        {
+            "@id": "lepton_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Lepton Party of Farallon",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Leptonicon",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "state_farallon"
+            ],
+            "@type": "ElectionResults.Party"
+        },
+        {
+            "@id": "hadron_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Hadron Party",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Hadronicrat",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "county_gadget"
+            ],
+            "@type": "ElectionResults.Party"
+        }
+    ],
+    "Person": [
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Spacely-Cosmo",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Magnate"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Smith-Sally",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Professor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gomez-Hector",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Artist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Davis-Rosashawn",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Writer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Tsi-Oliver",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Industrialist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Orotund-Glavin",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Baker"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Alpha-Anthony",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "US Senator"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Beta-Betty",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gamma-Gloria",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Doctor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Delta-David",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Business Owner"
+                    }
+                ]
+            }
+        }
+    ],
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "Name": {
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Gadget County General Election 2062"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "Type": "general",
+            "ElectionScopeId": "county_gadget",
+            "StartDate": "2062-06-15",
+            "EndDate": "2062-06-15",
+            "Candidate": [
+                {
+                    "@id": "candidate_spacely",
+                    "PersonId": "Person_Spacely-Cosmo",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Cosmo Spacely",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_cogswell",
+                    "PersonId": "Person_Cogswell-Spencer",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Spencer Cogswell",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_smith",
+                    "PersonId": "Person_Smith-Sally",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Sally Smith",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gomez",
+                    "PersonId": "Person_Gomez-Hector",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Hector Gomez",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_davis",
+                    "PersonId": "Person_Davis-Rosashawn",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rosashawn Davis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_tsi",
+                    "PersonId": "Person_Tsi-Oliver",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Oliver Tsi",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_orotund",
+                    "PersonId": "Person_Orotund-Glavin",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Glavin Orotund",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_alpha",
+                    "PersonId": "Person_Alpha-Anthony",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Anthony Alpha",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gamma",
+                    "PersonId": "Person_Gamma-Gloria",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Gloria Gamma",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_beta",
+                    "PersonId": "Person_Beta-Betty",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Betty Beta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_delta",
+                    "PersonId": "Person_Delta-David",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "David Delta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                }
+            ],
+            "BallotStyle": [
+                {
+                    "GpUnitIds": [
+                        "precinct_1_downtown"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "HeaderId": "header_national",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_9",
+                                    "OrderedContestSelectionIds": [
+                                        "lepton_ticket",
+                                        "hadron_ticket",
+                                        "presidential_write-in"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_state",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_6",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_6.1",
+                                        "selection_6.2"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_county",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_4",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_smith",
+                                        "selection_gomez",
+                                        "selection_davis",
+                                        "selection_tsi",
+                                        "selection_orotund",
+                                        "selection_4.6",
+                                        "selection_4.7",
+                                        "selection_4.8"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                },
+                                {
+                                    "ContestId": "contest_3",
+                                    "OrderedContestSelectionIds": [
+                                        "contest_3_yes",
+                                        "contest_3_no"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_district",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest-orbit-city-mayor",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_spacely",
+                                        "selection_cogswell",
+                                        "selection_writein_1"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        }
+                    ],
+                    "@type": "ElectionResults.BallotStyle"
+                }
+            ],
+            "Contest": [
+                {
+                    "OfficeIds": [
+                        "office_mayor"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest-orbit-city-mayor",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_spacely"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_spacely",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_cogswell"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_cogswell",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_1",
+                            "SequenceOrder": 3
+                        }
+                    ],
+                    "ElectionDistrictId": "district_orbit_city",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "VoteVariation": "plurality"
+                },
+                {
+                    "NumberElected": 2,
+                    "OfficeIds": [
+                        "office_control_board"
+                    ],
+                    "VotesAllowed": 2,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_2",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_jetson"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_jetson",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_ellis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_ellis",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_indexer"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_indexer",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_2",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_3",
+                            "SequenceOrder": 5
+                        }
+                    ],
+                    "ElectionDistrictId": "district_aldrin_spaceport",
+                    "Name": "Spaceport Control Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_3",
+                    "ElectionDistrictId": "county_gadget",
+                    "Name": "Air Traffic Control Tax Increase",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "Yes",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_yes",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "No",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_no",
+                            "SequenceOrder": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_6",
+                    "ElectionDistrictId": "state_farallon",
+                    "Name": "A Constitutional Amendment to Legalize Helium Balloons",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State\u2019s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                            }
+                        ]
+                    },
+                    "SummaryText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State\u2019s medical helium program. The scope of the commission\u2019s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State\u2019s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_1",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_2",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "No"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "NumberElected": 3,
+                    "OfficeIds": [
+                        "office_school_board"
+                    ],
+                    "VotesAllowed": 3,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_4",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_smith"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_smith",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gomez"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_gomez",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_davis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_davis",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_tsi"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_tsi",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_orotund"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_orotund",
+                            "SequenceOrder": 5
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.6",
+                            "SequenceOrder": 6
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.7",
+                            "SequenceOrder": 7
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.8",
+                            "SequenceOrder": 8
+                        }
+                    ],
+                    "ElectionDistrictId": "district_unified_school_district",
+                    "Name": "Gadget County School Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "OfficeIds": [
+                        "potus",
+                        "vpotus"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_9",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_alpha",
+                                "candidate_beta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "lepton_ticket"
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gamma",
+                                "candidate_delta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "hadron_ticket"
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "presidential_write-in"
+                        }
+                    ],
+                    "ElectionDistrictId": "country_usa",
+                    "Name": "President of the United States",
+                    "VoteVariation": "plurality"
+                }
+            ]
+        }
+    ]
+}

--- a/test_cases/edf_jetsons_precinct_2.json
+++ b/test_cases/edf_jetsons_precinct_2.json
@@ -1,0 +1,1042 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Format": "precinct-level",
+    "GeneratedDate": "2062-01-01T12:00:00-08:00",
+    "VendorApplicationId": "TTV",
+    "Issuer": "Gadget County",
+    "IssuerAbbreviation": "gc",
+    "SequenceStart": 1,
+    "SequenceEnd": 1,
+    "Status": "pre-election",
+    "Header": [
+        {
+            "@id": "header_national",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "National Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_state",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "State Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_county",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "County Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_district",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "District Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        }
+    ],
+    "GpUnit": [
+        {
+            "Type": "precinct",
+            "@type": "ElectionResults.ReportingUnit",
+            "@id": "precinct_2_spacetown",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Spacetown Precinct",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            }
+        }
+    ],
+    "Office": [
+        {
+            "@id": "office_mayor",
+            "ElectionDistrictId": "district_orbit_city",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "office_control_board",
+            "IsPartisan": false,
+            "ElectionDistrictId": "district_aldrin_spaceport",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Spaceport Control Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "office_school_board",
+            "ElectionDistrictId": "district_unified_school_district",
+            "IsPartisan": false,
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Gadget County School Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "potus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "vpotus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Vice President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        }
+    ],
+    "Party": [
+        {
+            "@id": "lepton_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Lepton Party of Farallon",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Leptonicon",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "state_farallon"
+            ],
+            "@type": "ElectionResults.Party"
+        },
+        {
+            "@id": "hadron_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Hadron Party",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Hadronicrat",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "county_gadget"
+            ],
+            "@type": "ElectionResults.Party"
+        }
+    ],
+    "Person": [
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Jetson-Jane",
+            "DateOfBirth": "2030-02-15",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Consultant"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Ellis-Harlan",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Electrician"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Indexer-Rudy",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Spacely-Cosmo",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Magnate"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Smith-Sally",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Professor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gomez-Hector",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Artist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Davis-Rosashawn",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Writer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Tsi-Oliver",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Industrialist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Orotund-Glavin",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Baker"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Alpha-Anthony",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "US Senator"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Beta-Betty",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gamma-Gloria",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Doctor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Delta-David",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Business Owner"
+                    }
+                ]
+            }
+        }
+    ],
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "Name": {
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Gadget County General Election 2062"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "Type": "general",
+            "ElectionScopeId": "county_gadget",
+            "StartDate": "2062-06-15",
+            "EndDate": "2062-06-15",
+            "Candidate": [
+                {
+                    "@id": "candidate_spacely",
+                    "PersonId": "Person_Spacely-Cosmo",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Cosmo Spacely",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_cogswell",
+                    "PersonId": "Person_Cogswell-Spencer",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Spencer Cogswell",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_jetson",
+                    "PersonId": "Person_Jetson-Jane",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Jane Jetson",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_ellis",
+                    "PersonId": "Person_Ellis-Harlan",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Harlan Ellis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_indexer",
+                    "PersonId": "Person_Indexer-Rudy",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rudy Indexer",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_smith",
+                    "PersonId": "Person_Smith-Sally",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Sally Smith",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gomez",
+                    "PersonId": "Person_Gomez-Hector",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Hector Gomez",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_davis",
+                    "PersonId": "Person_Davis-Rosashawn",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rosashawn Davis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_tsi",
+                    "PersonId": "Person_Tsi-Oliver",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Oliver Tsi",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_orotund",
+                    "PersonId": "Person_Orotund-Glavin",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Glavin Orotund",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_alpha",
+                    "PersonId": "Person_Alpha-Anthony",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Anthony Alpha",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gamma",
+                    "PersonId": "Person_Gamma-Gloria",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Gloria Gamma",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_beta",
+                    "PersonId": "Person_Beta-Betty",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Betty Beta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_delta",
+                    "PersonId": "Person_Delta-David",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "David Delta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                }
+            ],
+            "BallotStyle": [
+                {
+                    "GpUnitIds": [
+                        "precinct_2_spacetown"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "HeaderId": "header_national",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_9",
+                                    "OrderedContestSelectionIds": [
+                                        "lepton_ticket",
+                                        "hadron_ticket",
+                                        "presidential_write-in"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_state",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_6",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_6.1",
+                                        "selection_6.2"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_county",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_4",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_smith",
+                                        "selection_gomez",
+                                        "selection_davis",
+                                        "selection_tsi",
+                                        "selection_orotund",
+                                        "selection_4.6",
+                                        "selection_4.7",
+                                        "selection_4.8"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                },
+                                {
+                                    "ContestId": "contest_3",
+                                    "OrderedContestSelectionIds": [
+                                        "contest_3_yes",
+                                        "contest_3_no"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_district",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest-orbit-city-mayor",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_spacely",
+                                        "selection_cogswell",
+                                        "selection_writein_1"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                },
+                                {
+                                    "ContestId": "contest_2",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_jetson",
+                                        "selection_ellis",
+                                        "selection_indexer",
+                                        "selection_writein_2",
+                                        "selection_writein_3"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        }
+                    ],
+                    "@type": "ElectionResults.BallotStyle"
+                }
+            ],
+            "Contest": [
+                {
+                    "OfficeIds": [
+                        "office_mayor"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest-orbit-city-mayor",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_spacely"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_spacely",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_cogswell"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_cogswell",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_1",
+                            "SequenceOrder": 3
+                        }
+                    ],
+                    "ElectionDistrictId": "district_orbit_city",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "VoteVariation": "plurality"
+                },
+                {
+                    "NumberElected": 2,
+                    "OfficeIds": [
+                        "office_control_board"
+                    ],
+                    "VotesAllowed": 2,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_2",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_jetson"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_jetson",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_ellis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_ellis",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_indexer"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_indexer",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_2",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_3",
+                            "SequenceOrder": 5
+                        }
+                    ],
+                    "ElectionDistrictId": "district_aldrin_spaceport",
+                    "Name": "Spaceport Control Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_3",
+                    "ElectionDistrictId": "county_gadget",
+                    "Name": "Air Traffic Control Tax Increase",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "Yes",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_yes",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "No",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_no",
+                            "SequenceOrder": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_6",
+                    "ElectionDistrictId": "state_farallon",
+                    "Name": "A Constitutional Amendment to Legalize Helium Balloons",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State\u2019s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                            }
+                        ]
+                    },
+                    "SummaryText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State\u2019s medical helium program. The scope of the commission\u2019s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State\u2019s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_1",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_2",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "No"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "NumberElected": 3,
+                    "OfficeIds": [
+                        "office_school_board"
+                    ],
+                    "VotesAllowed": 3,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_4",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_smith"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_smith",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gomez"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_gomez",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_davis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_davis",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_tsi"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_tsi",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_orotund"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_orotund",
+                            "SequenceOrder": 5
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.6",
+                            "SequenceOrder": 6
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.7",
+                            "SequenceOrder": 7
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.8",
+                            "SequenceOrder": 8
+                        }
+                    ],
+                    "ElectionDistrictId": "district_unified_school_district",
+                    "Name": "Gadget County School Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "OfficeIds": [
+                        "potus",
+                        "vpotus"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_9",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_alpha",
+                                "candidate_beta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "lepton_ticket"
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gamma",
+                                "candidate_delta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "hadron_ticket"
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "presidential_write-in"
+                        }
+                    ],
+                    "ElectionDistrictId": "country_usa",
+                    "Name": "President of the United States",
+                    "VoteVariation": "plurality"
+                }
+            ]
+        }
+    ]
+}

--- a/test_cases/edf_jetsons_precinct_3.json
+++ b/test_cases/edf_jetsons_precinct_3.json
@@ -1,0 +1,970 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Format": "precinct-level",
+    "GeneratedDate": "2062-01-01T12:00:00-08:00",
+    "VendorApplicationId": "TTV",
+    "Issuer": "Gadget County",
+    "IssuerAbbreviation": "gc",
+    "SequenceStart": 1,
+    "SequenceEnd": 1,
+    "Status": "pre-election",
+    "Header": [
+        {
+            "@id": "header_national",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "National Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_state",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "State Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_county",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "County Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_district",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "District Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        }
+    ],
+    "GpUnit": [
+        {
+            "Type": "precinct",
+            "@type": "ElectionResults.ReportingUnit",
+            "@id": "precinct_3_spaceport",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Spaceport Precinct",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            }
+        }
+    ],
+    "Office": [
+        {
+            "@id": "office_control_board",
+            "IsPartisan": false,
+            "ElectionDistrictId": "district_aldrin_spaceport",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Spaceport Control Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "office_school_board",
+            "ElectionDistrictId": "district_unified_school_district",
+            "IsPartisan": false,
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Gadget County School Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "potus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "vpotus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Vice President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        }
+    ],
+    "Party": [
+        {
+            "@id": "lepton_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Lepton Party of Farallon",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Leptonicon",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "state_farallon"
+            ],
+            "@type": "ElectionResults.Party"
+        },
+        {
+            "@id": "hadron_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Hadron Party",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Hadronicrat",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "county_gadget"
+            ],
+            "@type": "ElectionResults.Party"
+        }
+    ],
+    "Person": [
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Jetson-Jane",
+            "DateOfBirth": "2030-02-15",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Consultant"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Ellis-Harlan",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Electrician"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Indexer-Rudy",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Smith-Sally",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Professor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gomez-Hector",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Artist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Davis-Rosashawn",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Writer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Tsi-Oliver",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Industrialist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Orotund-Glavin",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Baker"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Alpha-Anthony",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "US Senator"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Beta-Betty",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gamma-Gloria",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Doctor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Delta-David",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Business Owner"
+                    }
+                ]
+            }
+        }
+    ],
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "Name": {
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Gadget County General Election 2062"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "Type": "general",
+            "ElectionScopeId": "county_gadget",
+            "StartDate": "2062-06-15",
+            "EndDate": "2062-06-15",
+            "Candidate": [
+                {
+                    "@id": "candidate_jetson",
+                    "PersonId": "Person_Jetson-Jane",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Jane Jetson",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_ellis",
+                    "PersonId": "Person_Ellis-Harlan",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Harlan Ellis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_indexer",
+                    "PersonId": "Person_Indexer-Rudy",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rudy Indexer",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_smith",
+                    "PersonId": "Person_Smith-Sally",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Sally Smith",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gomez",
+                    "PersonId": "Person_Gomez-Hector",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Hector Gomez",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_davis",
+                    "PersonId": "Person_Davis-Rosashawn",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rosashawn Davis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_tsi",
+                    "PersonId": "Person_Tsi-Oliver",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Oliver Tsi",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_orotund",
+                    "PersonId": "Person_Orotund-Glavin",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Glavin Orotund",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_alpha",
+                    "PersonId": "Person_Alpha-Anthony",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Anthony Alpha",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gamma",
+                    "PersonId": "Person_Gamma-Gloria",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Gloria Gamma",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_beta",
+                    "PersonId": "Person_Beta-Betty",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Betty Beta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_delta",
+                    "PersonId": "Person_Delta-David",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "David Delta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                }
+            ],
+            "BallotStyle": [
+                {
+                    "GpUnitIds": [
+                        "precinct_3_spaceport"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "HeaderId": "header_national",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_9",
+                                    "OrderedContestSelectionIds": [
+                                        "lepton_ticket",
+                                        "hadron_ticket",
+                                        "presidential_write-in"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_state",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_6",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_6.1",
+                                        "selection_6.2"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_county",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_4",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_smith",
+                                        "selection_gomez",
+                                        "selection_davis",
+                                        "selection_tsi",
+                                        "selection_orotund",
+                                        "selection_4.6",
+                                        "selection_4.7",
+                                        "selection_4.8"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                },
+                                {
+                                    "ContestId": "contest_3",
+                                    "OrderedContestSelectionIds": [
+                                        "contest_3_yes",
+                                        "contest_3_no"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_district",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_2",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_jetson",
+                                        "selection_ellis",
+                                        "selection_indexer",
+                                        "selection_writein_2",
+                                        "selection_writein_3"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        }
+                    ],
+                    "@type": "ElectionResults.BallotStyle"
+                }
+            ],
+            "Contest": [
+                {
+                    "OfficeIds": [
+                        "office_mayor"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest-orbit-city-mayor",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_spacely"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_spacely",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_cogswell"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_cogswell",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_1",
+                            "SequenceOrder": 3
+                        }
+                    ],
+                    "ElectionDistrictId": "district_orbit_city",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "VoteVariation": "plurality"
+                },
+                {
+                    "NumberElected": 2,
+                    "OfficeIds": [
+                        "office_control_board"
+                    ],
+                    "VotesAllowed": 2,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_2",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_jetson"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_jetson",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_ellis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_ellis",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_indexer"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_indexer",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_2",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_3",
+                            "SequenceOrder": 5
+                        }
+                    ],
+                    "ElectionDistrictId": "district_aldrin_spaceport",
+                    "Name": "Spaceport Control Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_3",
+                    "ElectionDistrictId": "county_gadget",
+                    "Name": "Air Traffic Control Tax Increase",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "Yes",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_yes",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "No",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_no",
+                            "SequenceOrder": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_6",
+                    "ElectionDistrictId": "state_farallon",
+                    "Name": "A Constitutional Amendment to Legalize Helium Balloons",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State\u2019s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                            }
+                        ]
+                    },
+                    "SummaryText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State\u2019s medical helium program. The scope of the commission\u2019s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State\u2019s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_1",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_2",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "No"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "NumberElected": 3,
+                    "OfficeIds": [
+                        "office_school_board"
+                    ],
+                    "VotesAllowed": 3,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_4",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_smith"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_smith",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gomez"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_gomez",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_davis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_davis",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_tsi"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_tsi",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_orotund"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_orotund",
+                            "SequenceOrder": 5
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.6",
+                            "SequenceOrder": 6
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.7",
+                            "SequenceOrder": 7
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.8",
+                            "SequenceOrder": 8
+                        }
+                    ],
+                    "ElectionDistrictId": "district_unified_school_district",
+                    "Name": "Gadget County School Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "OfficeIds": [
+                        "potus",
+                        "vpotus"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_9",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_alpha",
+                                "candidate_beta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "lepton_ticket"
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gamma",
+                                "candidate_delta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "hadron_ticket"
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "presidential_write-in"
+                        }
+                    ],
+                    "ElectionDistrictId": "country_usa",
+                    "Name": "President of the United States",
+                    "VoteVariation": "plurality"
+                }
+            ]
+        }
+    ]
+}

--- a/test_cases/edf_jetsons_precinct_4.json
+++ b/test_cases/edf_jetsons_precinct_4.json
@@ -1,0 +1,829 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Format": "precinct-level",
+    "GeneratedDate": "2062-01-01T12:00:00-08:00",
+    "VendorApplicationId": "TTV",
+    "Issuer": "Gadget County",
+    "IssuerAbbreviation": "gc",
+    "SequenceStart": 1,
+    "SequenceEnd": 1,
+    "Status": "pre-election",
+    "Header": [
+        {
+            "@id": "header_national",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "National Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_state",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "State Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        },
+        {
+            "@id": "header_county",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "County Contests",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Header"
+        }
+    ],
+    "GpUnit": [
+        {
+            "Type": "precinct",
+            "@type": "ElectionResults.ReportingUnit",
+            "@id": "precinct_4_bedrock",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Bedrock Precinct",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            }
+        }
+    ],
+    "Office": [
+        {
+            "@id": "office_school_board",
+            "ElectionDistrictId": "district_unified_school_district",
+            "IsPartisan": false,
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Gadget County School Board",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "potus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        },
+        {
+            "@id": "vpotus",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "Vice President of the United States",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "@type": "ElectionResults.Office"
+        }
+    ],
+    "Party": [
+        {
+            "@id": "lepton_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Lepton Party of Farallon",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Leptonicon",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "state_farallon"
+            ],
+            "@type": "ElectionResults.Party"
+        },
+        {
+            "@id": "hadron_party",
+            "Name": {
+                "Text": [
+                    {
+                        "Content": "The Hadron Party",
+                        "Language": "en",
+                        "@type": "ElectionResults.LanguageString"
+                    }
+                ],
+                "Label": "Hadronicrat",
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "PartyScopeGpUnitIds": [
+                "county_gadget"
+            ],
+            "@type": "ElectionResults.Party"
+        }
+    ],
+    "Person": [
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Smith-Sally",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Professor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gomez-Hector",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Artist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Davis-Rosashawn",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Writer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Tsi-Oliver",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Industrialist"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Orotund-Glavin",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Baker"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Alpha-Anthony",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "US Senator"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Beta-Betty",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Lawyer"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Gamma-Gloria",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Doctor"
+                    }
+                ]
+            }
+        },
+        {
+            "@type": "ElectionResults.Person",
+            "@id": "Person_Delta-David",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Business Owner"
+                    }
+                ]
+            }
+        }
+    ],
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "Name": {
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Language": "en",
+                        "Content": "Gadget County General Election 2062"
+                    }
+                ],
+                "@type": "ElectionResults.InternationalizedText"
+            },
+            "Type": "general",
+            "ElectionScopeId": "county_gadget",
+            "StartDate": "2062-06-15",
+            "EndDate": "2062-06-15",
+            "Candidate": [
+                {
+                    "@id": "candidate_smith",
+                    "PersonId": "Person_Smith-Sally",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Sally Smith",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gomez",
+                    "PersonId": "Person_Gomez-Hector",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Hector Gomez",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_davis",
+                    "PersonId": "Person_Davis-Rosashawn",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Rosashawn Davis",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_tsi",
+                    "PersonId": "Person_Tsi-Oliver",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Oliver Tsi",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_orotund",
+                    "PersonId": "Person_Orotund-Glavin",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Glavin Orotund",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_alpha",
+                    "PersonId": "Person_Alpha-Anthony",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Anthony Alpha",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_gamma",
+                    "PersonId": "Person_Gamma-Gloria",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Gloria Gamma",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "IsTopTicket": true,
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_beta",
+                    "PersonId": "Person_Beta-Betty",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "Betty Beta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "lepton_party",
+                    "@type": "ElectionResults.Candidate"
+                },
+                {
+                    "@id": "candidate_delta",
+                    "PersonId": "Person_Delta-David",
+                    "BallotName": {
+                        "Text": [
+                            {
+                                "Content": "David Delta",
+                                "Language": "en",
+                                "@type": "ElectionResults.LanguageString"
+                            }
+                        ],
+                        "@type": "ElectionResults.InternationalizedText"
+                    },
+                    "PartyId": "hadron_party",
+                    "@type": "ElectionResults.Candidate"
+                }
+            ],
+            "BallotStyle": [
+                {
+                    "GpUnitIds": [
+                        "precinct_4_bedrock"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "HeaderId": "header_national",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_9",
+                                    "OrderedContestSelectionIds": [
+                                        "lepton_ticket",
+                                        "hadron_ticket",
+                                        "presidential_write-in"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_state",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_6",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_6.1",
+                                        "selection_6.2"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        },
+                        {
+                            "HeaderId": "header_county",
+                            "OrderedContent": [
+                                {
+                                    "ContestId": "contest_4",
+                                    "OrderedContestSelectionIds": [
+                                        "selection_smith",
+                                        "selection_gomez",
+                                        "selection_davis",
+                                        "selection_tsi",
+                                        "selection_orotund",
+                                        "selection_4.6",
+                                        "selection_4.7",
+                                        "selection_4.8"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                },
+                                {
+                                    "ContestId": "contest_3",
+                                    "OrderedContestSelectionIds": [
+                                        "contest_3_yes",
+                                        "contest_3_no"
+                                    ],
+                                    "@type": "ElectionResults.OrderedContest"
+                                }
+                            ],
+                            "@type": "ElectionResults.OrderedHeader"
+                        }
+                    ],
+                    "@type": "ElectionResults.BallotStyle"
+                }
+            ],
+            "Contest": [
+                {
+                    "OfficeIds": [
+                        "office_mayor"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest-orbit-city-mayor",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_spacely"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_spacely",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_cogswell"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_cogswell",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_1",
+                            "SequenceOrder": 3
+                        }
+                    ],
+                    "ElectionDistrictId": "district_orbit_city",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "VoteVariation": "plurality"
+                },
+                {
+                    "NumberElected": 2,
+                    "OfficeIds": [
+                        "office_control_board"
+                    ],
+                    "VotesAllowed": 2,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_2",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_jetson"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_jetson",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_ellis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_ellis",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_indexer"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_indexer",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_2",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_writein_3",
+                            "SequenceOrder": 5
+                        }
+                    ],
+                    "ElectionDistrictId": "district_aldrin_spaceport",
+                    "Name": "Spaceport Control Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_3",
+                    "ElectionDistrictId": "county_gadget",
+                    "Name": "Air Traffic Control Tax Increase",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?"
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "Yes",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_yes",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "Selection": {
+                                "Text": [
+                                    {
+                                        "Content": "No",
+                                        "Language": "en",
+                                        "@type": "ElectionResults.LanguageString"
+                                    }
+                                ],
+                                "@type": "ElectionResults.InternationalizedText"
+                            },
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "contest_3_no",
+                            "SequenceOrder": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "@id": "contest_6",
+                    "ElectionDistrictId": "state_farallon",
+                    "Name": "A Constitutional Amendment to Legalize Helium Balloons",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State\u2019s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                            }
+                        ]
+                    },
+                    "SummaryText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Language": "en",
+                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State\u2019s medical helium program. The scope of the commission\u2019s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State\u2019s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
+                            }
+                        ]
+                    },
+                    "ContestSelection": [
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_1",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "Yes"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "@id": "bm_1_2",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Language": "en",
+                                        "Content": "No"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "NumberElected": 3,
+                    "OfficeIds": [
+                        "office_school_board"
+                    ],
+                    "VotesAllowed": 3,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_4",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_smith"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_smith",
+                            "SequenceOrder": 1
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gomez"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_gomez",
+                            "SequenceOrder": 2
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_davis"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_davis",
+                            "SequenceOrder": 3
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_tsi"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_tsi",
+                            "SequenceOrder": 4
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_orotund"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_orotund",
+                            "SequenceOrder": 5
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.6",
+                            "SequenceOrder": 6
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.7",
+                            "SequenceOrder": 7
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "selection_4.8",
+                            "SequenceOrder": 8
+                        }
+                    ],
+                    "ElectionDistrictId": "district_unified_school_district",
+                    "Name": "Gadget County School Board",
+                    "VoteVariation": "n-of-m"
+                },
+                {
+                    "OfficeIds": [
+                        "potus",
+                        "vpotus"
+                    ],
+                    "VotesAllowed": 1,
+                    "@type": "ElectionResults.CandidateContest",
+                    "@id": "contest_9",
+                    "ContestSelection": [
+                        {
+                            "CandidateIds": [
+                                "candidate_alpha",
+                                "candidate_beta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "lepton_ticket"
+                        },
+                        {
+                            "CandidateIds": [
+                                "candidate_gamma",
+                                "candidate_delta"
+                            ],
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "hadron_ticket"
+                        },
+                        {
+                            "IsWriteIn": true,
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "presidential_write-in"
+                        }
+                    ],
+                    "ElectionDistrictId": "country_usa",
+                    "Name": "President of the United States",
+                    "VoteVariation": "plurality"
+                }
+            ]
+        }
+    ]
+}

--- a/test_cases/example_2.json
+++ b/test_cases/example_2.json
@@ -72,7 +72,7 @@
             "Type": "country",
             "@id": "country_usa",
             "ComposingGpUnitIds": ["state_farallon"],
-                        "Name": {
+            "Name": {
                 "Text": [
                     {
                         "Content": "United States of America",
@@ -327,7 +327,6 @@
                     }
                 ],
                 "Label": "Leptonicon",
-
                 "@type": "ElectionResults.InternationalizedText"
             },
 
@@ -450,7 +449,7 @@
                 ]
             }
         },
-                {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Gomez-Hector",
             "FirstName": "Hector",
@@ -466,7 +465,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Davis-Rosashawn",
             "FirstName": "Hector",
@@ -482,7 +481,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Tsi-Oliver",
             "FirstName": "Oliver",
@@ -498,7 +497,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Orotund-Glavin",
             "FirstName": "Glavin",
@@ -514,7 +513,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Alpha-Anthony",
             "FirstName": "Anthony",
@@ -530,7 +529,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Beta-Betty",
             "FirstName": "Betty",
@@ -546,7 +545,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Gamma-Gloria",
             "FirstName": "Gloria",
@@ -562,7 +561,7 @@
                 ]
             }
         },
-                       {
+        {
             "@type": "ElectionResults.Person",
             "@id": "Person_Delta-David",
             "FirstName": "David",
@@ -577,7 +576,7 @@
                     }
                 ]
             }
-        }        
+        }
     ],
     "Election": [
         {
@@ -817,7 +816,6 @@
                 }
             ],
             "BallotStyle": [
-
                 {
                     "GpUnitIds": ["precinct_1_downtown"],
                     "OrderedContent": [
@@ -1129,8 +1127,7 @@
                     "@type": "ElectionResults.BallotStyle"
                 }
             ],
-           
-           "Contest": [
+            "Contest": [
                 {
                     "OfficeIds": ["office_mayor"],
                     "VotesAllowed": 1,

--- a/test_cases/example_2.json
+++ b/test_cases/example_2.json
@@ -1365,44 +1365,6 @@
                     "VoteVariation": "n-of-m"
                 },
                 {
-                    "@id": "contest_6",
-                    "ContestSelection": [
-                        {
-                            "Selection": {
-                                "Text": [
-                                    {
-                                        "Content": "Yes",
-                                        "Language": "en",
-                                        "@type": "ElectionResults.LanguageString"
-                                    }
-                                ],
-                                "@type": "ElectionResults.InternationalizedText"
-                            },
-                            "@type": "ElectionResults.BallotMeasureSelection",
-                            "@id": "selection_6.1",
-                            "SequenceOrder": 1
-                        },
-                        {
-                            "Selection": {
-                                "Text": [
-                                    {
-                                        "Content": "No",
-                                        "Language": "en",
-                                        "@type": "ElectionResults.LanguageString"
-                                    }
-                                ],
-                                "@type": "ElectionResults.InternationalizedText"
-                            },
-                            "@type": "ElectionResults.BallotMeasureSelection",
-                            "@id": "selection_6.2",
-                            "SequenceOrder": 2
-                        }
-                    ],
-                    "ElectionDistrictId": "state_farallon",
-                    "Name": "Constitutional Amendment to Legalize Helium Balloons",
-                    "@type": "ElectionResults.BallotMeasureContest"
-                },
-                {
                     "OfficeIds": [
                         "potus",
                         "vpotus"

--- a/test_cases/example_2.json
+++ b/test_cases/example_2.json
@@ -71,7 +71,9 @@
             "@type": "ElectionResults.ReportingUnit",
             "Type": "country",
             "@id": "country_usa",
-            "ComposingGpUnitIds": ["state_farallon"],
+            "ComposingGpUnitIds": [
+                "state_farallon"
+            ],
             "Name": {
                 "Text": [
                     {
@@ -87,7 +89,9 @@
             "Type": "state",
             "@type": "ElectionResults.ReportingUnit",
             "@id": "state_farallon",
-            "ComposingGpUnitIds": ["county_gadget"],
+            "ComposingGpUnitIds": [
+                "county_gadget"
+            ],
             "Name": {
                 "Text": [
                     {
@@ -329,8 +333,9 @@
                 "Label": "Leptonicon",
                 "@type": "ElectionResults.InternationalizedText"
             },
-
-            "PartyScopeGpUnitIds": ["state_farallon"],
+            "PartyScopeGpUnitIds": [
+                "state_farallon"
+            ],
             "@type": "ElectionResults.Party"
         },
         {
@@ -346,8 +351,9 @@
                 "Label": "Hadronicrat",
                 "@type": "ElectionResults.InternationalizedText"
             },
-
-            "PartyScopeGpUnitIds": ["county_gadget"],
+            "PartyScopeGpUnitIds": [
+                "county_gadget"
+            ],
             "@type": "ElectionResults.Party"
         }
     ],
@@ -817,7 +823,9 @@
             ],
             "BallotStyle": [
                 {
-                    "GpUnitIds": ["precinct_1_downtown"],
+                    "GpUnitIds": [
+                        "precinct_1_downtown"
+                    ],
                     "OrderedContent": [
                         {
                             "HeaderId": "header_national",
@@ -895,7 +903,9 @@
                     "@type": "ElectionResults.BallotStyle"
                 },
                 {
-                    "GpUnitIds": ["precinct_2_spacetown"],
+                    "GpUnitIds": [
+                        "precinct_2_spacetown"
+                    ],
                     "OrderedContent": [
                         {
                             "HeaderId": "header_national",
@@ -984,7 +994,9 @@
                     "@type": "ElectionResults.BallotStyle"
                 },
                 {
-                    "GpUnitIds": ["precinct_3_spaceport"],
+                    "GpUnitIds": [
+                        "precinct_3_spaceport"
+                    ],
                     "OrderedContent": [
                         {
                             "HeaderId": "header_national",
@@ -1064,7 +1076,9 @@
                     "@type": "ElectionResults.BallotStyle"
                 },
                 {
-                    "GpUnitIds": ["precinct_4_bedrock"],
+                    "GpUnitIds": [
+                        "precinct_4_bedrock"
+                    ],
                     "OrderedContent": [
                         {
                             "HeaderId": "header_national",
@@ -1129,19 +1143,25 @@
             ],
             "Contest": [
                 {
-                    "OfficeIds": ["office_mayor"],
+                    "OfficeIds": [
+                        "office_mayor"
+                    ],
                     "VotesAllowed": 1,
                     "@type": "ElectionResults.CandidateContest",
                     "@id": "contest-orbit-city-mayor",
                     "ContestSelection": [
                         {
-                            "CandidateIds": ["candidate_spacely"],
+                            "CandidateIds": [
+                                "candidate_spacely"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_spacely",
                             "SequenceOrder": 1
                         },
                         {
-                            "CandidateIds": ["candidate_cogswell"],
+                            "CandidateIds": [
+                                "candidate_cogswell"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_cogswell",
                             "SequenceOrder": 2
@@ -1159,25 +1179,33 @@
                 },
                 {
                     "NumberElected": 2,
-                    "OfficeIds": ["office_control_board"],
+                    "OfficeIds": [
+                        "office_control_board"
+                    ],
                     "VotesAllowed": 2,
                     "@type": "ElectionResults.CandidateContest",
                     "@id": "contest_2",
                     "ContestSelection": [
                         {
-                            "CandidateIds": ["candidate_jetson"],
+                            "CandidateIds": [
+                                "candidate_jetson"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_jetson",
                             "SequenceOrder": 1
                         },
                         {
-                            "CandidateIds": ["candidate_ellis"],
+                            "CandidateIds": [
+                                "candidate_ellis"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_ellis",
                             "SequenceOrder": 2
                         },
                         {
-                            "CandidateIds": ["candidate_indexer"],
+                            "CandidateIds": [
+                                "candidate_indexer"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_indexer",
                             "SequenceOrder": 3
@@ -1258,7 +1286,7 @@
                             {
                                 "@type": "ElectionResults.LanguageString",
                                 "Language": "en",
-                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State\u2019s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?\nOnly adults at least 21 years of age could use helium. The State commission created to oversee the State’s medical helium program would also oversee the new, personal use helium market.\nHelium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons."
                             }
                         ]
                     },
@@ -1268,7 +1296,7 @@
                             {
                                 "@type": "ElectionResults.LanguageString",
                                 "Language": "en",
-                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State\u2019s medical helium program. The scope of the commission\u2019s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State\u2019s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
+                                "Content": "This amendment would legalize a controlled form of helium to be used to inflate balloons.  Only persons at least 21 years of age could inflate helium balloons legally.The Helium Regulatory Commission would oversee the new adult helium market. This commission was created in 2045 to oversee the State’s medical helium program. The scope of the commission’s new authority would be detailed in laws enacted by the Legislature.\nAll retail sales of helium products in the new adult helium market would be subject to the State’s sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium products."
                             }
                         ]
                     },
@@ -1305,38 +1333,49 @@
                 },
                 {
                     "NumberElected": 3,
-                    "OfficeIds": ["office_school_board"],
+                    "OfficeIds": [
+                        "office_school_board"
+                    ],
                     "VotesAllowed": 3,
                     "@type": "ElectionResults.CandidateContest",
                     "@id": "contest_4",
                     "ContestSelection": [
                         {
-                            "CandidateIds": ["candidate_smith"],
-
+                            "CandidateIds": [
+                                "candidate_smith"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_smith",
                             "SequenceOrder": 1
                         },
                         {
-                            "CandidateIds": ["candidate_gomez"],
+                            "CandidateIds": [
+                                "candidate_gomez"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_gomez",
                             "SequenceOrder": 2
                         },
                         {
-                            "CandidateIds": ["candidate_davis"],
+                            "CandidateIds": [
+                                "candidate_davis"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_davis",
                             "SequenceOrder": 3
                         },
                         {
-                            "CandidateIds": ["candidate_tsi"],
+                            "CandidateIds": [
+                                "candidate_tsi"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_tsi",
                             "SequenceOrder": 4
                         },
                         {
-                            "CandidateIds": ["candidate_orotund"],
+                            "CandidateIds": [
+                                "candidate_orotund"
+                            ],
                             "@type": "ElectionResults.CandidateSelection",
                             "@id": "selection_orotund",
                             "SequenceOrder": 5

--- a/test_cases/june_precinct_1_test_case.json
+++ b/test_cases/june_precinct_1_test_case.json
@@ -1,0 +1,842 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_1_downtown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recFIehh5Aj0zGTn6"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recOZMDz6uSf5A1NH",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Sally Smith",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recjdr7s1JWS9eB7J"
+                },
+                {
+                    "@id": "reccQRyca6A6QpRuo",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Hector Gomez",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recSUfKMVoKsAAMkS"
+                },
+                {
+                    "@id": "rec56yn7vK7Vk5Zbv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rosashawn Davis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recMZnE37A32cUq8t"
+                },
+                {
+                    "@id": "recSlC9yfxdyUA94v",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Oliver Tsi",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec15uIXhHcriFgTS"
+                },
+                {
+                    "@id": "recx71NmYNa1DNFIu",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Glavin Orotund",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recCHZSZuP5uTRqdk"
+                },
+                {
+                    "@id": "reczKIKk81RshXkd9",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Anthony Alpha",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "rec0YJkyHfiT4PBT6"
+                },
+                {
+                    "@id": "recLB4X1sLL2q1bSW",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Betty Beta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recUSqUnlKb63WT3F"
+                },
+                {
+                    "@id": "recopGzcpflkyhwdN",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Gloria Gamma",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec1R5Sy3JzkIC2Di"
+                },
+                {
+                    "@id": "recBEqMDC9w5AnKxh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "David Delta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec4Z3OQJv0YY8hhR"
+                },
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recthF6jdx5ybBNkC",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recbxvhKikHJNZYbq",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recOZMDz6uSf5A1NH"
+                            ]
+                        },
+                        {
+                            "@id": "recigPkqYXXDJEaCE",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reccQRyca6A6QpRuo"
+                            ]
+                        },
+                        {
+                            "@id": "recJvikmG5MrUKzo1",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec56yn7vK7Vk5Zbv"
+                            ]
+                        },
+                        {
+                            "@id": "recvjB3rgfiicf0RP",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recSlC9yfxdyUA94v"
+                            ]
+                        },
+                        {
+                            "@id": "recbN7UUMaSuOYGQ6",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recx71NmYNa1DNFIu"
+                            ]
+                        },
+                        {
+                            "@id": "recYurH2CLY3SlYS8",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recI5jfcXIsbAKytC",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recn9m0o1em7gLahj",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "Name": "Gadget County School Board",
+                    "OfficeIds": [
+                        "rec1zWmGWlgKKmUO4"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 4
+                },
+                {
+                    "@id": "recsoZy7vYhS3lbcK",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recPod2L8VhwagiDl",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recQK3J9IJq42hz2n",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reczKIKk81RshXkd9",
+                                "recLB4X1sLL2q1bSW"
+                            ]
+                        },
+                        {
+                            "@id": "reccUkUdEznfODgeL",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recopGzcpflkyhwdN",
+                                "recBEqMDC9w5AnKxh"
+                            ]
+                        }
+                    ],
+                    "ElectionDistrictId": "recTXCMIfa5VQJju2",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "https://viaf.org/viaf/",
+                            "Type": "other",
+                            "Value": "129529146"
+                        }
+                    ],
+                    "Name": "President of the United States",
+                    "OfficeIds": [
+                        "recFr8nr6uAZsD2r8"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recWjDBFeafCdklWq",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "rec7mVWjUH6fmDxig",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "reccIHOhUfJgJkqS7",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "rec93s713Yh6ZJT31",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Constitutional Amendment"
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recTXCMIfa5VQJju2",
+            "EndDate": "2024-11-05",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "General Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2024-11-05",
+            "Type": "general"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-18T09:29:52+00:00",
+    "GpUnit": [
+        {
+            "@id": "recFIehh5Aj0zGTn6",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Downtown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Downtown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec1zWmGWlgKKmUO4",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "School Board",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County School Board",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec15uIXhHcriFgTS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "industrialist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recCHZSZuP5uTRqdk",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "baker",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recMZnE37A32cUq8t",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rosashawn",
+            "LastName": "Davis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "writer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recSUfKMVoKsAAMkS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "artist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recjdr7s1JWS9eB7J",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "professor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/june_precinct_2_test_case.json
+++ b/test_cases/june_precinct_2_test_case.json
@@ -1,0 +1,753 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_4_bedrock"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recSQ3ZpvJlTll1Ve"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recOZMDz6uSf5A1NH",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Sally Smith",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recjdr7s1JWS9eB7J"
+                },
+                {
+                    "@id": "reccQRyca6A6QpRuo",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Hector Gomez",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recSUfKMVoKsAAMkS"
+                },
+                {
+                    "@id": "rec56yn7vK7Vk5Zbv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rosashawn Davis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recMZnE37A32cUq8t"
+                },
+                {
+                    "@id": "recSlC9yfxdyUA94v",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Oliver Tsi",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec15uIXhHcriFgTS"
+                },
+                {
+                    "@id": "recx71NmYNa1DNFIu",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Glavin Orotund",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recCHZSZuP5uTRqdk"
+                },
+                {
+                    "@id": "reczKIKk81RshXkd9",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Anthony Alpha",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "rec0YJkyHfiT4PBT6"
+                },
+                {
+                    "@id": "recLB4X1sLL2q1bSW",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Betty Beta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recUSqUnlKb63WT3F"
+                },
+                {
+                    "@id": "recopGzcpflkyhwdN",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Gloria Gamma",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec1R5Sy3JzkIC2Di"
+                },
+                {
+                    "@id": "recBEqMDC9w5AnKxh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "David Delta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec4Z3OQJv0YY8hhR"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recthF6jdx5ybBNkC",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recbxvhKikHJNZYbq",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recOZMDz6uSf5A1NH"
+                            ]
+                        },
+                        {
+                            "@id": "recigPkqYXXDJEaCE",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reccQRyca6A6QpRuo"
+                            ]
+                        },
+                        {
+                            "@id": "recJvikmG5MrUKzo1",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec56yn7vK7Vk5Zbv"
+                            ]
+                        },
+                        {
+                            "@id": "recvjB3rgfiicf0RP",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recSlC9yfxdyUA94v"
+                            ]
+                        },
+                        {
+                            "@id": "recbN7UUMaSuOYGQ6",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recx71NmYNa1DNFIu"
+                            ]
+                        },
+                        {
+                            "@id": "recYurH2CLY3SlYS8",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recI5jfcXIsbAKytC",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recn9m0o1em7gLahj",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "Name": "Gadget County School Board",
+                    "OfficeIds": [
+                        "rec1zWmGWlgKKmUO4"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 4
+                },
+                {
+                    "@id": "recsoZy7vYhS3lbcK",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recPod2L8VhwagiDl",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recQK3J9IJq42hz2n",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reczKIKk81RshXkd9",
+                                "recLB4X1sLL2q1bSW"
+                            ]
+                        },
+                        {
+                            "@id": "reccUkUdEznfODgeL",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recopGzcpflkyhwdN",
+                                "recBEqMDC9w5AnKxh"
+                            ]
+                        }
+                    ],
+                    "ElectionDistrictId": "recTXCMIfa5VQJju2",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "https://viaf.org/viaf/",
+                            "Type": "other",
+                            "Value": "129529146"
+                        }
+                    ],
+                    "Name": "President of the United States",
+                    "OfficeIds": [
+                        "recFr8nr6uAZsD2r8"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recWjDBFeafCdklWq",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "rec7mVWjUH6fmDxig",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "reccIHOhUfJgJkqS7",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "rec93s713Yh6ZJT31",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Constitutional Amendment"
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recTXCMIfa5VQJju2",
+            "EndDate": "2024-11-05",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "General Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2024-11-05",
+            "Type": "general"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-18T09:29:52+00:00",
+    "GpUnit": [
+        {
+            "@id": "recSQ3ZpvJlTll1Ve",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Bedrock",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Bedrock Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec1zWmGWlgKKmUO4",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "School Board",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County School Board",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec15uIXhHcriFgTS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "industrialist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recCHZSZuP5uTRqdk",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "baker",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recMZnE37A32cUq8t",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rosashawn",
+            "LastName": "Davis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "writer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recSUfKMVoKsAAMkS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "artist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recjdr7s1JWS9eB7J",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "professor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/june_precinct_3_test_case.json
+++ b/test_cases/june_precinct_3_test_case.json
@@ -1,0 +1,688 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_3_spaceport"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "rec7dCergEa3mzqxy"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "reczKIKk81RshXkd9",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Anthony Alpha",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "rec0YJkyHfiT4PBT6"
+                },
+                {
+                    "@id": "recLB4X1sLL2q1bSW",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Betty Beta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recUSqUnlKb63WT3F"
+                },
+                {
+                    "@id": "recopGzcpflkyhwdN",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Gloria Gamma",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec1R5Sy3JzkIC2Di"
+                },
+                {
+                    "@id": "recBEqMDC9w5AnKxh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "David Delta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec4Z3OQJv0YY8hhR"
+                },
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recthF6jdx5ybBNkC",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recbxvhKikHJNZYbq",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recOZMDz6uSf5A1NH"
+                            ]
+                        },
+                        {
+                            "@id": "recigPkqYXXDJEaCE",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reccQRyca6A6QpRuo"
+                            ]
+                        },
+                        {
+                            "@id": "recJvikmG5MrUKzo1",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec56yn7vK7Vk5Zbv"
+                            ]
+                        },
+                        {
+                            "@id": "recvjB3rgfiicf0RP",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recSlC9yfxdyUA94v"
+                            ]
+                        },
+                        {
+                            "@id": "recbN7UUMaSuOYGQ6",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recx71NmYNa1DNFIu"
+                            ]
+                        },
+                        {
+                            "@id": "recYurH2CLY3SlYS8",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recI5jfcXIsbAKytC",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recn9m0o1em7gLahj",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "Name": "Gadget County School Board",
+                    "OfficeIds": [
+                        "rec1zWmGWlgKKmUO4"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 4
+                },
+                {
+                    "@id": "recsoZy7vYhS3lbcK",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recPod2L8VhwagiDl",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recQK3J9IJq42hz2n",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reczKIKk81RshXkd9",
+                                "recLB4X1sLL2q1bSW"
+                            ]
+                        },
+                        {
+                            "@id": "reccUkUdEznfODgeL",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recopGzcpflkyhwdN",
+                                "recBEqMDC9w5AnKxh"
+                            ]
+                        }
+                    ],
+                    "ElectionDistrictId": "recTXCMIfa5VQJju2",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "https://viaf.org/viaf/",
+                            "Type": "other",
+                            "Value": "129529146"
+                        }
+                    ],
+                    "Name": "President of the United States",
+                    "OfficeIds": [
+                        "recFr8nr6uAZsD2r8"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recWjDBFeafCdklWq",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "rec7mVWjUH6fmDxig",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "reccIHOhUfJgJkqS7",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "rec93s713Yh6ZJT31",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Constitutional Amendment"
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recTXCMIfa5VQJju2",
+            "EndDate": "2024-11-05",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "General Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2024-11-05",
+            "Type": "general"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-18T09:29:52+00:00",
+    "GpUnit": [
+        {
+            "@id": "rec7dCergEa3mzqxy",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Port",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Port Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/june_precinct_4_test_case.json
+++ b/test_cases/june_precinct_4_test_case.json
@@ -1,0 +1,962 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_2_spacetown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recUuJTc3tUIUvgF1"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recOZMDz6uSf5A1NH",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Sally Smith",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recjdr7s1JWS9eB7J"
+                },
+                {
+                    "@id": "reccQRyca6A6QpRuo",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Hector Gomez",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recSUfKMVoKsAAMkS"
+                },
+                {
+                    "@id": "rec56yn7vK7Vk5Zbv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rosashawn Davis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recMZnE37A32cUq8t"
+                },
+                {
+                    "@id": "recSlC9yfxdyUA94v",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Oliver Tsi",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec15uIXhHcriFgTS"
+                },
+                {
+                    "@id": "recx71NmYNa1DNFIu",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Glavin Orotund",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recCHZSZuP5uTRqdk"
+                },
+                {
+                    "@id": "reczKIKk81RshXkd9",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Anthony Alpha",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "rec0YJkyHfiT4PBT6"
+                },
+                {
+                    "@id": "recLB4X1sLL2q1bSW",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Betty Beta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recUSqUnlKb63WT3F"
+                },
+                {
+                    "@id": "recopGzcpflkyhwdN",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Gloria Gamma",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec1R5Sy3JzkIC2Di"
+                },
+                {
+                    "@id": "recBEqMDC9w5AnKxh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "David Delta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec4Z3OQJv0YY8hhR"
+                },
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                },
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recthF6jdx5ybBNkC",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recbxvhKikHJNZYbq",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recOZMDz6uSf5A1NH"
+                            ]
+                        },
+                        {
+                            "@id": "recigPkqYXXDJEaCE",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reccQRyca6A6QpRuo"
+                            ]
+                        },
+                        {
+                            "@id": "recJvikmG5MrUKzo1",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec56yn7vK7Vk5Zbv"
+                            ]
+                        },
+                        {
+                            "@id": "recvjB3rgfiicf0RP",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recSlC9yfxdyUA94v"
+                            ]
+                        },
+                        {
+                            "@id": "recbN7UUMaSuOYGQ6",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recx71NmYNa1DNFIu"
+                            ]
+                        },
+                        {
+                            "@id": "recYurH2CLY3SlYS8",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recI5jfcXIsbAKytC",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recn9m0o1em7gLahj",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "Name": "Gadget County School Board",
+                    "OfficeIds": [
+                        "rec1zWmGWlgKKmUO4"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 4
+                },
+                {
+                    "@id": "recsoZy7vYhS3lbcK",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recPod2L8VhwagiDl",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recQK3J9IJq42hz2n",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reczKIKk81RshXkd9",
+                                "recLB4X1sLL2q1bSW"
+                            ]
+                        },
+                        {
+                            "@id": "reccUkUdEznfODgeL",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recopGzcpflkyhwdN",
+                                "recBEqMDC9w5AnKxh"
+                            ]
+                        }
+                    ],
+                    "ElectionDistrictId": "recTXCMIfa5VQJju2",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "https://viaf.org/viaf/",
+                            "Type": "other",
+                            "Value": "129529146"
+                        }
+                    ],
+                    "Name": "President of the United States",
+                    "OfficeIds": [
+                        "recFr8nr6uAZsD2r8"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recWjDBFeafCdklWq",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "rec7mVWjUH6fmDxig",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "reccIHOhUfJgJkqS7",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "rec93s713Yh6ZJT31",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Constitutional Amendment"
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recTXCMIfa5VQJju2",
+            "EndDate": "2024-11-05",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "General Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2024-11-05",
+            "Type": "general"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-18T09:29:52+00:00",
+    "GpUnit": [
+        {
+            "@id": "recUuJTc3tUIUvgF1",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spacetown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spacetown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec1zWmGWlgKKmUO4",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "School Board",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County School Board",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec15uIXhHcriFgTS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "industrialist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recCHZSZuP5uTRqdk",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "baker",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recMZnE37A32cUq8t",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rosashawn",
+            "LastName": "Davis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "writer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recSUfKMVoKsAAMkS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "artist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recjdr7s1JWS9eB7J",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "professor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}

--- a/test_cases/june_test_case.json
+++ b/test_cases/june_test_case.json
@@ -1,0 +1,1391 @@
+{
+    "@type": "ElectionResults.ElectionReport",
+    "Election": [
+        {
+            "@type": "ElectionResults.Election",
+            "BallotStyle": [
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_1_downtown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recFIehh5Aj0zGTn6"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_4_bedrock"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recSQ3ZpvJlTll1Ve"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_3_spaceport"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "rec7dCergEa3mzqxy"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "@type": "ElectionResults.BallotStyle",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "TTV",
+                            "Type": "other",
+                            "Value": "precinct_2_spacetown"
+                        }
+                    ],
+                    "GpUnitIds": [
+                        "recUuJTc3tUIUvgF1"
+                    ],
+                    "OrderedContent": [
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recIj8OmzqzzvnDbM",
+                            "OrderedContestSelectionIds": [
+                                "recTKcXLCzRvKB9U0",
+                                "recKD6dBvkNhEU4bg",
+                                "recqq21kO6HWgpJZV"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recXNb4zPrvC1m6Fr",
+                            "OrderedContestSelectionIds": [
+                                "recvYvTb9hWH7tptb",
+                                "recBnJZEgCKAnfpNo",
+                                "recwNuOnepWNGz67V",
+                                "rec9Eev970VhohqKi",
+                                "recFiGYjGCIyk5LBe"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recthF6jdx5ybBNkC",
+                            "OrderedContestSelectionIds": [
+                                "recbxvhKikHJNZYbq",
+                                "recigPkqYXXDJEaCE",
+                                "recJvikmG5MrUKzo1",
+                                "recvjB3rgfiicf0RP",
+                                "recbN7UUMaSuOYGQ6",
+                                "recYurH2CLY3SlYS8",
+                                "recI5jfcXIsbAKytC",
+                                "recn9m0o1em7gLahj"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recsoZy7vYhS3lbcK",
+                            "OrderedContestSelectionIds": [
+                                "recPod2L8VhwagiDl",
+                                "recQK3J9IJq42hz2n",
+                                "reccUkUdEznfODgeL"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recqPa7AeyufIfd6k",
+                            "OrderedContestSelectionIds": [
+                                "recysACFx8cgwomBE",
+                                "recabXA9jzFYRmGXy"
+                            ]
+                        },
+                        {
+                            "@type": "ElectionResults.OrderedContest",
+                            "ContestId": "recWjDBFeafCdklWq",
+                            "OrderedContestSelectionIds": [
+                                "rec7mVWjUH6fmDxig",
+                                "reccIHOhUfJgJkqS7"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Candidate": [
+                {
+                    "@id": "recOZMDz6uSf5A1NH",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Sally Smith",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recjdr7s1JWS9eB7J"
+                },
+                {
+                    "@id": "reccQRyca6A6QpRuo",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Hector Gomez",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recSUfKMVoKsAAMkS"
+                },
+                {
+                    "@id": "rec56yn7vK7Vk5Zbv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rosashawn Davis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recMZnE37A32cUq8t"
+                },
+                {
+                    "@id": "recSlC9yfxdyUA94v",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Oliver Tsi",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec15uIXhHcriFgTS"
+                },
+                {
+                    "@id": "recx71NmYNa1DNFIu",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Glavin Orotund",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recCHZSZuP5uTRqdk"
+                },
+                {
+                    "@id": "reci9iNLcQ3rtAiLf",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for School Board 1",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "recjGuouIexifBZkh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for School Board 2",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "recrcHPI9yPhcL4HS",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for School Board 3",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "recWq31C2cZmioLYA",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-In for President",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "reczKIKk81RshXkd9",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Anthony Alpha",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "rec0YJkyHfiT4PBT6"
+                },
+                {
+                    "@id": "recLB4X1sLL2q1bSW",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Betty Beta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recUSqUnlKb63WT3F"
+                },
+                {
+                    "@id": "recopGzcpflkyhwdN",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Gloria Gamma",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec1R5Sy3JzkIC2Di"
+                },
+                {
+                    "@id": "recBEqMDC9w5AnKxh",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "David Delta",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "rec4Z3OQJv0YY8hhR"
+                },
+                {
+                    "@id": "recK4Vc1EdfBufEU4",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Cosmo Spacely",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "recBiK9LZXeZmmFEg",
+                    "PersonId": "recDl4dMHupCh8ex8"
+                },
+                {
+                    "@id": "recd1n9MadKRsYLUX",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Spencer Cogswell",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PartyId": "reckpEKRtLuDdt03n",
+                    "PersonId": "recS2gdD7iUKUM7ml"
+                },
+                {
+                    "@id": "recV5d7CnhUw5NoOl",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Mayor",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "rec72dETaScaK4tqv",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Jane Jetson",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "recUoaJjaziRvFTcr"
+                },
+                {
+                    "@id": "recWnqiDUAZupjFW8",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Harlan Ellis",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rec2vW1LMVneqPEXP"
+                },
+                {
+                    "@id": "recDqtLJ6IqwZJr7k",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Rudy Indexer",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "PersonId": "rechCFDgeqHybXkSY"
+                },
+                {
+                    "@id": "rec4qAek7djJBFktw",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Control Board 1",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "@id": "recVwhaX6QKaOPSjc",
+                    "@type": "ElectionResults.Candidate",
+                    "BallotName": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Write-in for Control Board 2",
+                                "Language": "en"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Contest": [
+                {
+                    "@id": "recthF6jdx5ybBNkC",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recbxvhKikHJNZYbq",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recOZMDz6uSf5A1NH"
+                            ]
+                        },
+                        {
+                            "@id": "recigPkqYXXDJEaCE",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reccQRyca6A6QpRuo"
+                            ]
+                        },
+                        {
+                            "@id": "recJvikmG5MrUKzo1",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec56yn7vK7Vk5Zbv"
+                            ]
+                        },
+                        {
+                            "@id": "recvjB3rgfiicf0RP",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recSlC9yfxdyUA94v"
+                            ]
+                        },
+                        {
+                            "@id": "recbN7UUMaSuOYGQ6",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recx71NmYNa1DNFIu"
+                            ]
+                        },
+                        {
+                            "@id": "recYurH2CLY3SlYS8",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recI5jfcXIsbAKytC",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recn9m0o1em7gLahj",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "Name": "Gadget County School Board",
+                    "OfficeIds": [
+                        "rec1zWmGWlgKKmUO4"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 4
+                },
+                {
+                    "@id": "recsoZy7vYhS3lbcK",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recPod2L8VhwagiDl",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recQK3J9IJq42hz2n",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "reczKIKk81RshXkd9",
+                                "recLB4X1sLL2q1bSW"
+                            ]
+                        },
+                        {
+                            "@id": "reccUkUdEznfODgeL",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recopGzcpflkyhwdN",
+                                "recBEqMDC9w5AnKxh"
+                            ]
+                        }
+                    ],
+                    "ElectionDistrictId": "recTXCMIfa5VQJju2",
+                    "ExternalIdentifier": [
+                        {
+                            "@type": "ElectionResults.ExternalIdentifier",
+                            "OtherType": "https://viaf.org/viaf/",
+                            "Type": "other",
+                            "Value": "129529146"
+                        }
+                    ],
+                    "Name": "President of the United States",
+                    "OfficeIds": [
+                        "recFr8nr6uAZsD2r8"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recIj8OmzqzzvnDbM",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recTKcXLCzRvKB9U0",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recK4Vc1EdfBufEU4"
+                            ]
+                        },
+                        {
+                            "@id": "recKD6dBvkNhEU4bg",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recd1n9MadKRsYLUX"
+                            ]
+                        },
+                        {
+                            "@id": "recqq21kO6HWgpJZV",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recfK8xOapcRIeZ2k",
+                    "Name": "Contest for Mayor of Orbit City",
+                    "OfficeIds": [
+                        "rec7N0cboW3L1Mv0I"
+                    ],
+                    "VoteVariation": "plurality",
+                    "VotesAllowed": 1
+                },
+                {
+                    "@id": "recXNb4zPrvC1m6Fr",
+                    "@type": "ElectionResults.CandidateContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recvYvTb9hWH7tptb",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "rec72dETaScaK4tqv"
+                            ]
+                        },
+                        {
+                            "@id": "recBnJZEgCKAnfpNo",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recWnqiDUAZupjFW8"
+                            ]
+                        },
+                        {
+                            "@id": "recwNuOnepWNGz67V",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "CandidateIds": [
+                                "recDqtLJ6IqwZJr7k"
+                            ]
+                        },
+                        {
+                            "@id": "rec9Eev970VhohqKi",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        },
+                        {
+                            "@id": "recFiGYjGCIyk5LBe",
+                            "@type": "ElectionResults.CandidateSelection",
+                            "IsWriteIn": true
+                        }
+                    ],
+                    "ElectionDistrictId": "recVN5dRsq4j6QZn3",
+                    "Name": "Spaceport Control Board",
+                    "OfficeIds": [
+                        "recBAG7iuOZ1MER6i"
+                    ],
+                    "VoteVariation": "n-of-m",
+                    "VotesAllowed": 2
+                },
+                {
+                    "@id": "recWjDBFeafCdklWq",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "rec7mVWjUH6fmDxig",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "reccIHOhUfJgJkqS7",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "rec93s713Yh6ZJT31",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Do you approve amending the Constitution to legalize the controlled use of helium balloons?  Only adults at least 21 years of age could use helium. The State commission created to oversee the State's medical helium program would also oversee the new, personal use helium market.Helium balloons would be subject to the State sales tax. If authorized by the Legislature, a municipality may pass a local ordinance to charge a local tax on helium balloons.",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Constitutional Amendment"
+                },
+                {
+                    "@id": "recqPa7AeyufIfd6k",
+                    "@type": "ElectionResults.BallotMeasureContest",
+                    "ContestSelection": [
+                        {
+                            "@id": "recysACFx8cgwomBE",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "Yes",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "@id": "recabXA9jzFYRmGXy",
+                            "@type": "ElectionResults.BallotMeasureSelection",
+                            "Selection": {
+                                "@type": "ElectionResults.InternationalizedText",
+                                "Text": [
+                                    {
+                                        "@type": "ElectionResults.LanguageString",
+                                        "Content": "No",
+                                        "Language": "en"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ElectionDistrictId": "recOVSnILnPJ7Dahl",
+                    "FullText": {
+                        "@type": "ElectionResults.InternationalizedText",
+                        "Text": [
+                            {
+                                "@type": "ElectionResults.LanguageString",
+                                "Content": "Shall Gadget County increase its sales tax from 1% to 1.1% for the purpose of raising additional revenue to fund expanded air traffic control operations?",
+                                "Language": "en"
+                            }
+                        ]
+                    },
+                    "Name": "Air Traffic Control Tax Increase"
+                }
+            ],
+            "ElectionScopeId": "recTXCMIfa5VQJju2",
+            "EndDate": "2024-11-05",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "General Election",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "StartDate": "2024-11-05",
+            "Type": "general"
+        }
+    ],
+    "Format": "precinct-level",
+    "GeneratedDate": "2022-06-18T09:29:52+00:00",
+    "GpUnit": [
+        {
+            "@id": "rec7dCergEa3mzqxy",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Port",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Port Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "rec93s713Yh6ZJT31",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Farallon",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The State of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "state"
+        },
+        {
+            "@id": "recFIehh5Aj0zGTn6",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Downtown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Downtown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recOVSnILnPJ7Dahl",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Gadget",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "county"
+        },
+        {
+            "@id": "recSQ3ZpvJlTll1Ve",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Bedrock",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Bedrock Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recTXCMIfa5VQJju2",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "USA",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "United States of America",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "country"
+        },
+        {
+            "@id": "recUuJTc3tUIUvgF1",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spacetown",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spacetown Precinct",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "precinct"
+        },
+        {
+            "@id": "recVAsRw7BvEIBnTe",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Gadget School District",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County Unified School District",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "school"
+        },
+        {
+            "@id": "recVN5dRsq4j6QZn3",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Aldrin Space Transport District",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "municipality"
+        },
+        {
+            "@id": "recfK8xOapcRIeZ2k",
+            "@type": "ElectionResults.ReportingUnit",
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Orbit City",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Type": "city"
+        }
+    ],
+    "Issuer": "TrustTheVote",
+    "IssuerAbbreviation": "TTV",
+    "Office": [
+        {
+            "@id": "rec1zWmGWlgKKmUO4",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "School Board",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Gadget County School Board",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec7N0cboW3L1Mv0I",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Mayor",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Mayor of Orbit City",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recBAG7iuOZ1MER6i",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": false,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Spaceport Control Board Member",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Spaceport Control Board Member",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recFr8nr6uAZsD2r8",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "POTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recIR57LPmJ0VvtEo",
+            "@type": "ElectionResults.Office",
+            "IsPartisan": true,
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "VPOTUS",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "Vice-President of the United States",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Party": [
+        {
+            "@id": "recBiK9LZXeZmmFEg",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "LEP",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Leptonican",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Lepton Party",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "reckpEKRtLuDdt03n",
+            "@type": "ElectionResults.Party",
+            "Abbreviation": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "HAD",
+                        "Language": "en"
+                    }
+                ]
+            },
+            "Name": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Label": "Hadronicrat",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "The Hadron Party of Farallon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "Person": [
+        {
+            "@id": "rec0YJkyHfiT4PBT6",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Anthony",
+            "LastName": "Alpha",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "senator",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec15uIXhHcriFgTS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Oliver",
+            "LastName": "Tsi",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "industrialist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec1R5Sy3JzkIC2Di",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Gloria",
+            "LastName": "Gamma",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "doctor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec2vW1LMVneqPEXP",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Harlan",
+            "LastName": "Ellis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "electician",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rec4Z3OQJv0YY8hhR",
+            "@type": "ElectionResults.Person",
+            "FirstName": "David",
+            "LastName": "Delta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "business owner",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recCHZSZuP5uTRqdk",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Glavin",
+            "LastName": "Orotund",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "baker",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recDl4dMHupCh8ex8",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Cosmo",
+            "LastName": "Spacely",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "magnate",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recMZnE37A32cUq8t",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rosashawn",
+            "LastName": "Davis",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "writer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recS2gdD7iUKUM7ml",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Spencer",
+            "LastName": "Cogswell",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "surgeon",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recSUfKMVoKsAAMkS",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Hector",
+            "LastName": "Gomez",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "artist",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUSqUnlKb63WT3F",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Betty",
+            "LastName": "Beta",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recUoaJjaziRvFTcr",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Jane",
+            "LastName": "Jetson",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "consultant",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "rechCFDgeqHybXkSY",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Rudy",
+            "LastName": "Indexer",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "lawyer",
+                        "Language": "en"
+                    }
+                ]
+            }
+        },
+        {
+            "@id": "recjdr7s1JWS9eB7J",
+            "@type": "ElectionResults.Person",
+            "FirstName": "Sally",
+            "LastName": "Smith",
+            "Profession": {
+                "@type": "ElectionResults.InternationalizedText",
+                "Text": [
+                    {
+                        "@type": "ElectionResults.LanguageString",
+                        "Content": "professor",
+                        "Language": "en"
+                    }
+                ]
+            }
+        }
+    ],
+    "SequenceEnd": 1,
+    "SequenceStart": 1,
+    "Status": "pre-election",
+    "VendorApplicationId": "ElectionReporter"
+}


### PR DESCRIPTION
This is a demonstration of a program that could create precinct specific EDFs from a larger EDF. It uses [`test_cases/example_2.json`](https://github.com/ion-oset/nist-1500-examples/blob/precinct-specific-edfs/test_cases/example_2.json) as its base and splits it into the 4 Jetsons precincts. Note that the current operation supported is "extract" which picks out a precinct a time. If this is approved we can "unpack" which extracts out _all_ the precincts.

The way to try it out:

- Install the project with Poetry.
- Run the following command:

```
    $ python scripts/extract-precincts.py test_cases/example_2.json {rev} -o {path/to/output/file}
```
- `{rev}` is a number from 0 to 3 (because there are 4 precincts).
- The output should match `test_cases/edf_jetsons_precinct_{rev}.json`
- If you want to see intermediate debugging output use one or more of the following debugging flags:
    - `--show document` to see the original EDF (long)
    - `--show index` to see the DOM-lite index of IDs and types
    - `--show selection` to see all the elements that the program identifies as being part of the precinct
    - `--show extraction` to see the output on the console (long)

Some things to be aware of:

- This branch is not intended to be merged. It's a PR so it can be reviewed.
- The branch is _not_ based off of the most recent [upstream `main`](https://github.com/ion-oset/nist-1500-examples/tree/main). The work was started a while ago and since it's an example there was no reason to update.
- Pydantic has [strict field ordering rules](https://pydantic-docs.helpmanual.io/usage/models/#field-ordering) designed to allow it to work properly and keep the serialization consistent. As a result using `nist-data-models` as this branch does results in **EDFs that do not preserve the order of fields in the generated precincts**. If you look at [the earlier revision that uses dictionaries instead of data models](https://github.com/ion-oset/nist-1500-examples/commit/f2f912d0) you _will_ be able to round-trip results. In practice the only disadvantage of the data models version is that it's not simple to verify that things work with a simple `diff`.